### PR TITLE
Add solve_banded numerical helper for banded SPD Hessians

### DIFF
--- a/cvxium/__init__.py
+++ b/cvxium/__init__.py
@@ -134,6 +134,7 @@ from .linear_programs import (
 )
 from .numerical_helpers import (
     solve_arrow_sparsity_pattern,
+    solve_banded,
     solve_block_plus_one,
     solve_diagonal,
     solve_diagonal_eta_inverse,
@@ -189,6 +190,7 @@ __all__ = [
     "SevereCurvatureError",
     "UnconstrainedNewtonSolver",
     "solve_arrow_sparsity_pattern",
+    "solve_banded",
     "solve_block_plus_one",
     "solve_diagonal",
     "solve_diagonal_eta_inverse",

--- a/cvxium/numerical_helpers.py
+++ b/cvxium/numerical_helpers.py
@@ -546,6 +546,73 @@ def solve_arrow_sparsity_pattern(
     return x
 
 
+def solve_banded(
+    b: npt.NDArray[np.float64],
+    ab: npt.NDArray[np.float64],
+    lower: bool = False,
+) -> npt.NDArray[np.float64]:
+    """Solve H * x = b.
+
+    Solves a linear system of equations where H is a symmetric positive-definite banded
+    matrix stored in the compact banded form used by ``scipy.linalg.cholesky_banded``.
+
+    Parameters
+    ----------
+     b : npt.NDArray[np.float64]
+        Right hand side. Can be either a vector or a matrix, in which case we solve the
+        system for each column of b.
+     ab : npt.NDArray[np.float64]
+        Banded storage of the symmetric positive-definite matrix H, shape ``(p+1, n)``
+        where ``n`` is the matrix order and ``p`` is the number of super-diagonals
+        (when ``lower=False``) or sub-diagonals (when ``lower=True``).
+        If ``lower=False`` (default): ``ab[i, j] = H[j - p + i, j]`` for valid indices.
+        If ``lower=True``: ``ab[i, j] = H[j + i, j]`` for valid indices.
+        To convert a dense symmetric matrix H with bandwidth p to upper banded form::
+
+            ab = np.zeros((p + 1, n))
+            for d in range(p + 1):
+                ab[p - d, d:] = np.diag(H, d)
+
+        To convert to lower banded form::
+
+            ab = np.zeros((p + 1, n))
+            for d in range(p + 1):
+                ab[d, : n - d] = np.diag(H, -d)
+
+     lower : bool, optional
+        Whether ``ab`` stores the lower (``True``) or upper (``False``, default)
+        triangular band.
+
+    Returns
+    -------
+     x : npt.NDArray[np.float64]
+        The solution.
+
+    Notes
+    -----
+    Uses ``scipy.linalg.cholesky_banded`` to compute the Cholesky factorization of H,
+    then ``scipy.linalg.cho_solve_banded`` to solve each right-hand side.  For a matrix
+    of order ``n`` with bandwidth ``p``, factorization costs O(n * p^2) and each solve
+    costs O(n * p), compared with O(n^3) and O(n^2) for the dense case.
+
+    """
+    if b.ndim not in (1, 2):
+        raise ValueError("b must be either a 1D or 2D NumPy array.")
+
+    n = ab.shape[1]
+    if b.shape[0] != n:
+        raise ValueError(
+            f"Dimension mismatch: b has {b.shape[0]} rows but ab implies n={n}."
+        )
+
+    try:
+        cb = linalg.cholesky_banded(ab, lower=lower)
+    except np.linalg.LinAlgError:
+        raise NewtonStepError("Hessian is not strictly positive definite.") from None
+
+    return linalg.cho_solve_banded((cb, lower), b)
+
+
 def solve_kkt_system(
     A: npt.NDArray[np.float64],
     g: npt.NDArray[np.float64],

--- a/test/test_numerical_helpers.py
+++ b/test/test_numerical_helpers.py
@@ -3,11 +3,13 @@
 import time
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 from scipy import linalg
 
 from cvxium.numerical_helpers import (
     solve_arrow_sparsity_pattern,
+    solve_banded,
     solve_block_plus_one,
     solve_diagonal,
     solve_kkt_system,
@@ -745,3 +747,102 @@ def test_solve_kkt_system_hessian_diagonal_plus_rank_one_rank_deficient(
 
     # Verify A * delta_w = 0
     np.testing.assert_allclose(lhs_bot, rhs_bot, rtol=1e-8, atol=1e-8)
+
+
+def _make_spd_banded(
+    n: int, p: int, rng: np.random.RandomState
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return (H, ab_upper, ab_lower) for a random SPD banded matrix.
+
+    H is the dense n-by-n matrix.  ab_upper and ab_lower are the upper and lower
+    banded storage forms accepted by scipy.linalg.cholesky_banded.
+    """
+    # Build a banded lower-triangular factor L, then H = L @ L^T
+    L = np.zeros((n, n))
+    for i in range(n):
+        L[i, i] = rng.rand() + 1.0
+        for k in range(1, min(p + 1, i + 1)):
+            L[i, i - k] = rng.randn() * 0.3
+    H = L @ L.T
+
+    # Upper banded form: ab_upper[p - d, d:] = diag(H, d)
+    ab_upper = np.zeros((p + 1, n))
+    for d in range(p + 1):
+        ab_upper[p - d, d:] = np.diag(H, d)
+
+    # Lower banded form: ab_lower[d, :n - d] = diag(H, -d)
+    ab_lower = np.zeros((p + 1, n))
+    for d in range(p + 1):
+        ab_lower[d, : n - d] = np.diag(H, -d)
+
+    return H, ab_upper, ab_lower
+
+
+@pytest.mark.parametrize(
+    "seed,M,p",
+    [
+        (117, 100, 3),
+        (217, 200, 5),
+        (317, 50, 2),
+        (417, 500, 10),
+        (517, 13, 2),
+    ],
+)
+def test_solve_banded(seed: int, M: int, p: int) -> None:
+    """Test solving H*x = b for a banded SPD matrix (single RHS)."""
+    rng = np.random.RandomState(seed)
+    H, ab_upper, ab_lower = _make_spd_banded(M, p, rng)
+    b = rng.randn(M)
+
+    st = time.time()
+    x_expected = np.linalg.solve(H, b)
+    mt = time.time()
+    x_upper = solve_banded(b, ab_upper, lower=False)
+    et = time.time()
+    x_lower = solve_banded(b, ab_lower, lower=True)
+    ft = time.time()
+
+    print(f"Slow way completed in {1e6 * (mt - st):.03f} us")
+    print(f"Fast way (upper) completed in {1e6 * (et - mt):.03f} us")
+    print(f"Fast way (lower) completed in {1e6 * (ft - et):.03f} us")
+
+    np.testing.assert_allclose(x_upper, x_expected, rtol=1e-8, atol=1e-8)
+    np.testing.assert_allclose(x_lower, x_expected, rtol=1e-8, atol=1e-8)
+
+    # Verify H*x = b
+    np.testing.assert_allclose(H @ x_upper, b, rtol=1e-8, atol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "seed,M,p,q",
+    [
+        (118, 100, 3, 20),
+        (218, 200, 5, 30),
+        (318, 50, 2, 5),
+        (418, 500, 10, 100),
+        (518, 13, 2, 3),
+    ],
+)
+def test_solve_banded_multiple_rhs(seed: int, M: int, p: int, q: int) -> None:
+    """Test solving H*x = B for a banded SPD matrix (multiple RHS)."""
+    rng = np.random.RandomState(seed)
+    H, ab_upper, ab_lower = _make_spd_banded(M, p, rng)
+    b = rng.randn(M, q)
+
+    st = time.time()
+    x_expected = np.linalg.solve(H, b)
+    mt = time.time()
+    x_upper = solve_banded(b, ab_upper, lower=False)
+    et = time.time()
+    x_lower = solve_banded(b, ab_lower, lower=True)
+    ft = time.time()
+
+    print(f"Slow way completed in {1e3 * (mt - st):.03f} ms")
+    print(f"Fast way (upper) completed in {1e3 * (et - mt):.03f} ms")
+    print(f"Fast way (lower) completed in {1e3 * (ft - et):.03f} ms")
+
+    np.testing.assert_allclose(x_upper, x_expected, rtol=1e-8, atol=1e-8)
+    np.testing.assert_allclose(x_lower, x_expected, rtol=1e-8, atol=1e-8)
+
+    # Verify H*x = b
+    np.testing.assert_allclose(H @ x_upper, b, rtol=1e-8, atol=1e-8)


### PR DESCRIPTION
Adds solve_banded(b, ab, lower=False) to numerical_helpers.py, which
solves H*x = b when H is symmetric positive-definite and banded. Uses
scipy.linalg.cholesky_banded + cho_solve_banded for O(n*p^2) factorization
and O(n*p) solve per RHS, versus O(n^3) and O(n^2) for the dense case.
Accepts both 1D (single RHS) and 2D (multiple RHS) b arrays, and both
upper (lower=False) and lower (lower=True) banded storage forms.

Exports the function from __init__.py and adds 10 parametrized tests
covering single and multiple RHS across various matrix sizes (n=13..500)
and bandwidths (p=2..10), verifying both upper and lower storage forms
against numpy.linalg.solve.

https://claude.ai/code/session_0127AySeE5MeESWjzXbUENwb