### PR TITLE
Add EqualityConstrainedNewtonSolver for equality-constrained Newton's method

### DIFF
--- a/cvxium/__init__.py
+++ b/cvxium/__init__.py
@@ -145,6 +145,7 @@ from .numerical_helpers import (
 )
 from .optimization import (
     EqualityConstrainedInteriorPointMethodSolver,
+    EqualityConstrainedNewtonSolver,
     InteriorPointMethodResult,
     InteriorPointMethodSolver,
     NewtonResult,
@@ -158,6 +159,7 @@ from .optimization import (
     UnconstrainedNewtonSolver,
 )
 from .quadratic_programs import (
+    QuadraticEqualityConstrainedNewtonSolver,
     QuadraticNewtonSolver,
     QuadraticProgramEqualityBoundsSolver,
 )
@@ -167,6 +169,7 @@ __all__ = [
     "CenteringStepError",
     "ConstraintBoundaryError",
     "EqualityConstrainedInteriorPointMethodSolver",
+    "EqualityConstrainedNewtonSolver",
     "EqualitySolver",
     "EqualityWithBoundsAndImbalanceConstraintSolver",
     "EqualityWithBoundsSolver",
@@ -185,6 +188,7 @@ __all__ = [
     "ProblemCertifiablyInfeasibleError",
     "ProblemInfeasibleError",
     "ProblemMarginallyFeasibleError",
+    "QuadraticEqualityConstrainedNewtonSolver",
     "QuadraticNewtonSolver",
     "QuadraticProgramEqualityBoundsSolver",
     "SevereCurvatureError",

--- a/cvxium/optimization.py
+++ b/cvxium/optimization.py
@@ -1356,3 +1356,151 @@ class UnconstrainedNewtonSolver(BaseInteriorPointMethodSolver):
     ) -> float:
         """Dual equals primal for unconstrained problems."""
         return self.evaluate_objective(x_star)
+
+
+class EqualityConstrainedNewtonSolver(BaseInteriorPointMethodSolver):
+    """Newton's method for equality-constrained problems (A x = b, no inequality constraints).
+
+    The barrier parameter is irrelevant without inequality constraints, so the outer IPM
+    loop is skipped entirely. Instead, Newton's method is applied directly to the
+    equality-constrained problem, computing each Newton step by solving the KKT system
+    rather than just the Hessian equation.
+
+    Usage
+    -----
+    Subclass this and implement:
+    - A: equality constraint matrix (p x n)
+    - b: equality constraint right-hand side (p,)
+    - newton_step: solve KKT system, return (delta_x, nu)
+    - evaluate_objective: f0(x)
+    - gradient: grad f0(x)
+    - hessian_vector_product: H(x) @ y
+
+    """
+
+    def __init__(
+        self,
+        settings: OptimizationSettings | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize solver."""
+        super().__init__(phase1_solver=None, settings=settings, **kwargs)
+
+    @abstractproperty
+    def A(self) -> npt.NDArray[np.float64]:  # noqa: N802
+        """Equality constraint matrix (p x n)."""
+
+    @abstractproperty
+    def b(self) -> npt.NDArray[np.float64]:
+        """Right-hand side of equality constraints (p,)."""
+
+    @property
+    def num_eq_constraints(self) -> int:
+        """Number of equality constraints."""
+        return len(self.b)
+
+    @property
+    def num_ineq_constraints(self) -> int:
+        """No inequality constraints."""
+        return 0
+
+    def solve(
+        self,
+        x0: npt.NDArray[np.float64] | None = None,
+        fully_optimize: bool = False,
+        **kwargs: Any,
+    ) -> NewtonResult:
+        """Solve equality-constrained problem using Newton's method.
+
+        Skips the outer barrier loop entirely and runs Newton's method once.
+
+        Parameters
+        ----------
+         x0 : vector
+            Initial guess. Should satisfy A x0 = b.
+         fully_optimize : bool
+            Unused; present for API compatibility with base class.
+
+        Returns
+        -------
+         res : NewtonResult
+
+        """
+        if x0 is None:
+            raise ValueError("Initial guess x0 is required.")
+        return self.centering_step(x0, t=1.0, last_step=True, fully_optimize=True)
+
+    def is_feasible(self, x: npt.NDArray[np.float64]) -> bool:
+        """All points are feasible (no inequality constraints)."""
+        return True
+
+    def constraints(self, x: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        """No inequality constraints."""
+        return np.zeros(0)
+
+    def grad_constraints(self, x: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        """No inequality constraints."""
+        return np.zeros((0, x.size))
+
+    def btls_keep_feasible(
+        self, x: npt.NDArray[np.float64], delta_x: npt.NDArray[np.float64]
+    ) -> float:
+        """No inequality constraints to maintain feasibility for; any step size is valid."""
+        return np.inf
+
+    @abstractmethod
+    def newton_step(
+        self, x: npt.NDArray[np.float64]
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        r"""Solve the KKT system and return (delta_x, nu).
+
+        Solves:
+
+           | H(x)   A^T | | delta_x |   | -grad_f0(x) |
+           |  A      0  | |   nu    | = |      0      |
+
+        Parameters
+        ----------
+         x : vector
+            Current iterate.
+
+        Returns
+        -------
+         delta_x : vector
+            Newton step for the primal variable.
+         nu : vector
+            Lagrange multipliers for the equality constraints.
+
+        """
+
+    @abstractmethod
+    def hessian_vector_product(
+        self, x: npt.NDArray[np.float64], y: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Compute H(x) @ y."""
+
+    def calculate_newton_step(
+        self,
+        x: npt.NDArray[np.float64],
+        t: float,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        """Newton step via KKT system; t is unused (always 1, no barrier)."""
+        return self.newton_step(x)
+
+    def hessian_multiply(
+        self,
+        x: npt.NDArray[np.float64],
+        t: float,
+        y: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
+        """Compute H(x) @ y; t is unused (always 1, no barrier)."""
+        return self.hessian_vector_product(x, y)
+
+    def evaluate_dual(
+        self,
+        lmbda: npt.NDArray[np.float64],
+        nu: npt.NDArray[np.float64],
+        x_star: npt.NDArray[np.float64],
+    ) -> float:
+        """Dual equals primal at optimality (strong duality, no inequality constraints)."""
+        return self.evaluate_objective(x_star)

--- a/cvxium/quadratic_programs.py
+++ b/cvxium/quadratic_programs.py
@@ -16,6 +16,7 @@ from .numerical_helpers import (
 )
 from .optimization import (
     EqualityConstrainedInteriorPointMethodSolver,
+    EqualityConstrainedNewtonSolver,
     InteriorPointMethodResult,
     InteriorPointMethodSolver,
     OptimizationSettings,
@@ -54,6 +55,79 @@ class QuadraticNewtonSolver(UnconstrainedNewtonSolver):
         self, x: npt.NDArray[np.float64], y: npt.NDArray[np.float64]
     ) -> npt.NDArray[np.float64]:
         return self.Q @ y
+
+
+class QuadraticEqualityConstrainedNewtonSolver(EqualityConstrainedNewtonSolver):
+    r"""Solve min 0.5 * x^T Q x + c^T x subject to A x = b, where Q is PD.
+
+    Optimal solution satisfies the KKT conditions:
+        Q x* + c + A^T nu* = 0
+        A x* = b.
+    """
+
+    def __init__(
+        self,
+        Q: npt.NDArray[np.float64],
+        c: npt.NDArray[np.float64],
+        A: npt.NDArray[np.float64],
+        b: npt.NDArray[np.float64],
+        settings: OptimizationSettings | None = None,
+    ) -> None:
+        super().__init__(settings=settings)
+        self.Q = Q
+        self.c = c
+        self._A = A
+        self._b = b
+        self._Q_factor = linalg.cho_factor(Q)
+
+    @property
+    def A(self) -> npt.NDArray[np.float64]:  # noqa: N802
+        """Equality constraint matrix."""
+        return self._A
+
+    @property
+    def b(self) -> npt.NDArray[np.float64]:
+        """Equality constraint right-hand side."""
+        return self._b
+
+    def newton_step(
+        self, x: npt.NDArray[np.float64]
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        """Solve the KKT system via the Schur complement."""
+        return solve_kkt_system(
+            A=self._A,
+            g=-(self.Q @ x + self.c),
+            hessian_solve=lambda rhs: linalg.cho_solve(self._Q_factor, rhs),
+        )
+
+    def evaluate_objective(self, x: npt.NDArray[np.float64]) -> float:
+        return float(0.5 * x @ self.Q @ x + self.c @ x)
+
+    def gradient(self, x: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return self.Q @ x + self.c
+
+    def hessian_vector_product(
+        self, x: npt.NDArray[np.float64], y: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        return self.Q @ y
+
+    def evaluate_dual(
+        self,
+        lmbda: npt.NDArray[np.float64],
+        nu: npt.NDArray[np.float64],
+        x_star: npt.NDArray[np.float64],
+    ) -> float:
+        r"""Evaluate the Lagrangian dual function g(nu).
+
+        The Lagrangian is L(x, nu) = 0.5 x^T Q x + c^T x + nu^T (A x - b).
+        Minimizing over x gives x*(nu) = -Q^{-1}(c + A^T nu), and:
+
+            g(nu) = -0.5 (c + A^T nu)^T Q^{-1} (c + A^T nu) - nu^T b.
+
+        """
+        v = self.c + self._A.T @ nu
+        Q_inv_v = linalg.cho_solve(self._Q_factor, v)
+        return float(-0.5 * np.dot(v, Q_inv_v) - np.dot(self._b, nu))
 
 
 def _callable_has_structured_params(fn: Callable[..., Any] | None) -> bool:

--- a/test/test_quadratic_programs.py
+++ b/test/test_quadratic_programs.py
@@ -9,6 +9,7 @@ from scipy import linalg, optimize
 
 from cvxium import NewtonResult
 from cvxium.quadratic_programs import (
+    QuadraticEqualityConstrainedNewtonSolver,
     QuadraticNewtonSolver,
     QuadraticProgramEqualityBoundsSolver,
 )
@@ -585,3 +586,72 @@ class TestStructuredQCallables:
         )
         np.testing.assert_allclose(A @ result_fast.solution, b, atol=1e-5)
         assert np.all(result_fast.solution >= xl - 1e-6)
+
+
+@pytest.mark.parametrize(
+    "seed,n,p",
+    [
+        (701, 5, 2),
+        (801, 10, 3),
+        (901, 20, 5),
+        (1101, 50, 10),
+        (1201, 100, 20),
+    ],
+)
+def test_equality_constrained_newton_quadratic(seed: int, n: int, p: int) -> None:
+    """EqualityConstrainedNewtonSolver finds the exact KKT point of a quadratic in one step."""
+    rng = np.random.default_rng(seed)
+
+    # Q = B^T B + I ensures strict positive definiteness.
+    B = rng.standard_normal((n, n))
+    Q = B.T @ B + np.eye(n)
+    c = rng.standard_normal(n)
+
+    # Build a feasible starting point x0 satisfying A x0 = b.
+    A = rng.standard_normal((p, n))
+    x0 = rng.standard_normal(n)
+    b = A @ x0
+
+    # Expected solution via direct KKT solve:
+    #   [ Q    A^T ] [ x*  ]   [ -c ]
+    #   [ A     0  ] [ nu* ] = [  b ]
+    KKT = np.block([[Q, A.T], [A, np.zeros((p, p))]])
+    rhs = np.concatenate([-c, b])
+    sol = linalg.solve(KKT, rhs)
+    x_star_expected = sol[:n]
+
+    solver = QuadraticEqualityConstrainedNewtonSolver(Q=Q, c=c, A=A, b=b)
+    result = solver.solve(x0=x0)
+
+    assert isinstance(result, NewtonResult)
+    np.testing.assert_allclose(result.solution, x_star_expected, rtol=1e-6, atol=1e-8)
+    np.testing.assert_allclose(A @ result.solution, b, atol=1e-8)
+    # Newton's method is exact for quadratics: one step reaches the optimum.
+    assert result.nits == 2
+
+
+@pytest.mark.parametrize(
+    "seed,n,p",
+    [
+        (2101, 10, 3),
+        (2201, 20, 5),
+        (2301, 50, 10),
+    ],
+)
+def test_equality_constrained_newton_quadratic_dual(seed: int, n: int, p: int) -> None:
+    """Dual value equals primal at the KKT point (zero duality gap)."""
+    rng = np.random.default_rng(seed)
+
+    B = rng.standard_normal((n, n))
+    Q = B.T @ B + np.eye(n)
+    c = rng.standard_normal(n)
+
+    A = rng.standard_normal((p, n))
+    x0 = rng.standard_normal(n)
+    b = A @ x0
+
+    solver = QuadraticEqualityConstrainedNewtonSolver(Q=Q, c=c, A=A, b=b)
+    result = solver.solve(x0=x0)
+
+    # At the KKT point, strong duality holds: dual = primal.
+    assert abs(result.objective_value - result.dual_value) < 1e-6


### PR DESCRIPTION
Adds a new base class EqualityConstrainedNewtonSolver that applies Newton's
method to problems with equality constraints A x = b but no inequality
constraints. Like UnconstrainedNewtonSolver, it bypasses the outer IPM loop
and runs a single centering step with t=1, but computes each Newton step by
solving the KKT system rather than just the Hessian equation.

Also adds QuadraticEqualityConstrainedNewtonSolver as a concrete example
(solves 0.5 x^T Q x + c^T x subject to A x = b) with tests verifying
exact one-step convergence and zero duality gap at the KKT point.

https://claude.ai/code/session_01WgUuSQct9Gr3YhmLdrjtdY