### PR TITLE
Add MultiObjectiveOptimizer for Pareto frontier tracing

### DIFF
--- a/cvxium/__init__.py
+++ b/cvxium/__init__.py
@@ -137,6 +137,11 @@ from .linear_programs import (
     EqualityWithBoundsAndImbalanceConstraintSolver,
     EqualityWithBoundsSolver,
 )
+from .multi_objective import (
+    FrontierPoint,
+    FrontierResults,
+    MultiObjectiveOptimizer,
+)
 from .numerical_helpers import (
     multiply_arrow_sparsity_pattern,
     multiply_banded,
@@ -205,11 +210,14 @@ __all__ = [
     "EqualityWithBoundsSolver",
     "FeasibilityInteriorPointSolver",
     "FeasibilitySolver",
+    "FrontierPoint",
+    "FrontierResults",
     "InteriorPointMethodError",
     "InteriorPointMethodResult",
     "InteriorPointMethodSolver",
     "InvalidDescentDirectionError",
     "IterationHandler",
+    "MultiObjectiveOptimizer",
     "NewtonResult",
     "NewtonStepError",
     "OptimizationError",

--- a/cvxium/multi_objective.py
+++ b/cvxium/multi_objective.py
@@ -166,9 +166,7 @@ class MultiObjectiveOptimizer(ABC):
         ...
 
     @abstractmethod
-    def minimize_objective(
-        self, objective_index: int
-    ) -> InteriorPointMethodResult:
+    def minimize_objective(self, objective_index: int) -> InteriorPointMethodResult:
         """Minimize a single objective with no bounds on the others.
 
         Used by :meth:`trace` to compute the N corner points of the frontier
@@ -289,8 +287,7 @@ class MultiObjectiveOptimizer(ABC):
 
         # --- Step 3: grid sweep ---
         grids = [
-            np.linspace(bounds_min[j], bounds_max[j], num_points)
-            for j in range(n_aux)
+            np.linspace(bounds_min[j], bounds_max[j], num_points) for j in range(n_aux)
         ]
 
         points: list[FrontierPoint] = list(corners)

--- a/cvxium/multi_objective.py
+++ b/cvxium/multi_objective.py
@@ -23,9 +23,8 @@ class FrontierPoint:
     solution : array
         The decision variable at this point.
     bounds : array of shape (N-1,)
-        The upper bounds on auxiliary objectives that were imposed when solving.
-        Set to ``np.full(N-1, np.inf)`` for corner points where no bounds were
-        imposed.
+        The upper bounds on auxiliary objectives that were imposed when solving. Set to
+        ``np.full(N-1, np.inf)`` for corner points where no bounds were imposed.
     ipm_result : InteriorPointMethodResult
         The raw result from the underlying solver.
 
@@ -43,23 +42,21 @@ class FrontierResults:
     Parameters
     ----------
     points : list[FrontierPoint]
-        All successfully evaluated points, including the corner points,
-        deduplicated by objective vector.
+        All successfully evaluated points, including the corner points, deduplicated by
+        objective vector.
     corners : list[FrontierPoint]
-        The N corner points, one per objective. ``corners[0]`` minimizes the
-        primary objective; ``corners[k]`` minimizes the k-th auxiliary objective
-        (in the order they appear in ``evaluate_objectives``, skipping the
-        primary). If a corner solve failed, fewer than N corners are stored and
-        :meth:`knee` will raise.
+        The N corner points, one per objective. ``corners[0]`` minimizes the primary
+        objective; ``corners[k]`` minimizes the k-th auxiliary objective (in the order
+        they appear in ``evaluate_objectives``, skipping the primary). If a corner solve
+        failed, fewer than N corners are stored and `knee` will raise.
     primary_objective : int
         Index of the primary objective.
     n_attempted : int
-        Number of grid points where :meth:`~MultiObjectiveOptimizer.solve_with_bounds`
-        was called.
+        Number of grid points where `MultiObjectiveOptimizer.solve_with_bounds` was
+        called.
     n_skipped : int
         Number of grid points that were skipped because the solver raised
-        :class:`~cvxium.OptimizationError` or
-        :class:`~cvxium.ProblemInfeasibleError`.
+        `cvxium.OptimizationError` or `cvxium.ProblemInfeasibleError`.
 
     """
 
@@ -80,18 +77,17 @@ class FrontierResults:
     def knee(self) -> FrontierPoint:
         """Return the frontier point maximally distant from the corner hyperplane.
 
-        Identifies the "knee in the curve" by finding the point on the frontier
-        farthest from the hyperplane that passes through the N corner points
-        (where N is the number of objectives). For two objectives this reduces
-        to the standard max-chord-distance method.
+        Identifies the "knee in the curve" by finding the point on the frontier farthest
+        from the hyperplane that passes through the N corner points (where N is the
+        number of objectives). For two objectives this reduces to the standard
+        max-chord-distance method.
 
-        The reference hyperplane is constructed by translating the corner points
-        so that ``corners[0]`` is at the origin, then finding the null-space of
-        the matrix whose rows are the remaining translated corners via SVD. This
-        requires the N corner points to be **affinely independent**: if they are
-        (nearly) coplanar in objective space the normal will be numerically
-        unreliable. The check ``norm == 0`` catches exact degeneracy; near-
-        degeneracy is not currently detected.
+        The reference hyperplane is constructed by translating the corner points so that
+        ``corners[0]`` is at the origin, then finding the null-space of the matrix whose
+        rows are the remaining translated corners via SVD. This requires the N corner
+        points to be **affinely independent**: if they are (nearly) coplanar in
+        objective space the normal will be numerically unreliable. The check ``norm ==
+        0`` catches exact degeneracy; near- degeneracy is not currently detected.
 
         Returns
         -------
@@ -100,9 +96,9 @@ class FrontierResults:
         Raises
         ------
         ValueError
-            If the frontier is empty, if fewer than N corners are available
-            (where N = number of objectives inferred from the first point), or
-            if the corner points are degenerate.
+            If the frontier is empty, if fewer than N corners are available (where N =
+            number of objectives inferred from the first point), or if the corner points
+            are degenerate.
 
         """
         if not self.points:
@@ -153,21 +149,20 @@ class MultiObjectiveOptimizer(ABC):
 
     To use this class, subclass it and implement:
 
-    - :meth:`solve_with_bounds` — minimize the primary objective subject to
-      upper bounds on each auxiliary objective.
-    - :meth:`minimize_objective` — minimize a single objective with no bounds
-      on the others.
-    - :meth:`evaluate_objectives` — return all N objective values at a point.
+    - `solve_with_bounds` — minimize the primary objective subject to upper bounds on
+      each auxiliary objective.
+    - `minimize_objective` — minimize a single objective with no bounds on the others.
+    - `evaluate_objectives` — return all N objective values at a point.
 
-    Then call :meth:`trace` to sweep over a uniform grid of auxiliary bounds
-    and collect the resulting Pareto-optimal points.
+    Then call `trace` to sweep over a uniform grid of auxiliary bounds and collect the
+    resulting Pareto-optimal points.
 
     Parameters
     ----------
     primary_objective : int, default=0
-        Index into the vector returned by :meth:`evaluate_objectives` that
-        identifies the objective to minimize during the frontier sweep. All
-        other objectives become auxiliary and receive parametric upper bounds.
+        Index into the vector returned by `evaluate_objectives` that identifies the
+        objective to minimize during the frontier sweep. All other objectives become
+        auxiliary and receive parametric upper bounds.
 
     """
 
@@ -183,9 +178,8 @@ class MultiObjectiveOptimizer(ABC):
         Parameters
         ----------
         bounds : array of shape (N-1,)
-            ``bounds[j]`` is the upper bound imposed on auxiliary objective
-            ``j`` (in the order objectives appear in :meth:`evaluate_objectives`,
-            skipping the primary).
+            ``bounds[j]`` is the upper bound imposed on auxiliary objective ``j`` (in
+            the order objectives appear in `evaluate_objectives`, skipping the primary).
 
         Returns
         -------
@@ -198,13 +192,13 @@ class MultiObjectiveOptimizer(ABC):
     def minimize_objective(self, objective_index: int) -> InteriorPointMethodResult:
         """Minimize a single objective with no bounds on the others.
 
-        Used by :meth:`trace` to compute the N corner points of the frontier
-        and to auto-detect the sweep range for each auxiliary objective.
+        Used by `trace` to compute the N corner points of the frontier and to
+        auto-detect the sweep range for each auxiliary objective.
 
         Parameters
         ----------
         objective_index : int
-            Index into the vector returned by :meth:`evaluate_objectives`.
+            Index into the vector returned by `evaluate_objectives`.
 
         Returns
         -------
@@ -227,8 +221,8 @@ class MultiObjectiveOptimizer(ABC):
         Returns
         -------
         array of shape (N,)
-            Objective values. The element at index ``self.primary_objective``
-            is the primary objective; all others are auxiliary.
+            Objective values. The element at index ``self.primary_objective`` is the
+            primary objective; all others are auxiliary.
 
         """
         ...
@@ -238,22 +232,20 @@ class MultiObjectiveOptimizer(ABC):
 
         Algorithm
         ---------
-        1. Call :meth:`minimize_objective` for every objective to get N corner
-           points and auto-detect the sweep range for each auxiliary.
+        1. Call `minimize_objective` for every objective to get N corner points and
+           auto-detect the sweep range for each auxiliary.
         2. Build a uniform grid of ``num_points`` values per auxiliary dimension
            spanning ``[bounds_min, bounds_max]``.
-        3. For each grid point, call :meth:`solve_with_bounds`; silently skip
-           any point that raises :class:`~cvxium.OptimizationError` or
-           :class:`~cvxium.ProblemInfeasibleError`.
-        4. Deduplicate by objective vector (within ``1e-8`` absolute tolerance),
-           then return all unique points together with the corners.
+        3. For each grid point, call `solve_with_bounds`; silently skip any point that
+           raises `cvxium.OptimizationError` or `cvxium.ProblemInfeasibleError`.
+        4. Deduplicate by objective vector (within ``1e-8`` absolute tolerance), then
+           return all unique points together with the corners.
 
         Parameters
         ----------
         num_points : int, default=50
-            Number of grid points along each auxiliary-objective dimension.
-            Total solves is at most ``N + num_points^(N-1)`` where ``N`` is
-            the number of objectives.
+            Number of grid points along each auxiliary-objective dimension. Total solves
+            is at most ``N + num_points^(N-1)`` where ``N`` is the number of objectives.
 
         Returns
         -------

--- a/cvxium/multi_objective.py
+++ b/cvxium/multi_objective.py
@@ -1,0 +1,325 @@
+"""Multi-objective optimization and Pareto frontier tracing."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from itertools import product as itertools_product
+
+import numpy as np
+import numpy.typing as npt
+from scipy import linalg
+
+from .exceptions import OptimizationError, ProblemInfeasibleError
+from .optimization import InteriorPointMethodResult
+
+
+@dataclass
+class FrontierPoint:
+    """A single evaluated point on the Pareto frontier.
+
+    Parameters
+    ----------
+    objectives : array of shape (N,)
+        The value of each objective at this point.
+    solution : array
+        The decision variable at this point.
+    bounds : array of shape (N-1,)
+        The upper bounds on auxiliary objectives that were imposed when solving.
+        Set to ``np.full(N-1, np.inf)`` for corner points where no bounds were
+        imposed.
+    ipm_result : InteriorPointMethodResult
+        The raw result from the underlying solver.
+
+    """
+
+    objectives: npt.NDArray[np.float64]
+    solution: npt.NDArray[np.float64]
+    bounds: npt.NDArray[np.float64]
+    ipm_result: InteriorPointMethodResult
+
+
+class FrontierResults:
+    """Results from tracing a Pareto frontier.
+
+    Parameters
+    ----------
+    points : list[FrontierPoint]
+        All successfully evaluated points, including the corner points.
+    corners : list[FrontierPoint]
+        The N corner points, one per objective. ``corners[0]`` minimizes the
+        primary objective; ``corners[k]`` minimizes the k-th auxiliary objective
+        (in the order they appear in ``evaluate_objectives``, skipping the
+        primary).
+    primary_objective : int
+        Index of the primary objective.
+
+    """
+
+    def __init__(
+        self,
+        points: list[FrontierPoint],
+        corners: list[FrontierPoint],
+        primary_objective: int,
+    ) -> None:
+        self.points = points
+        self.corners = corners
+        self.primary_objective = primary_objective
+
+    def knee(self) -> FrontierPoint:
+        """Return the frontier point maximally distant from the corner hyperplane.
+
+        Identifies the "knee in the curve" by finding the point on the frontier
+        farthest from the hyperplane that passes through the N corner points
+        (where N is the number of objectives). For two objectives this reduces
+        to the standard max-chord-distance method.
+
+        Returns
+        -------
+        FrontierPoint
+
+        Raises
+        ------
+        ValueError
+            If fewer than 2 corner points are available or the frontier is empty.
+
+        """
+        if not self.points:
+            raise ValueError("No frontier points to evaluate.")
+
+        n_corners = len(self.corners)
+        if n_corners < 2:
+            raise ValueError(
+                f"Need at least 2 corner points for knee calculation; got {n_corners}."
+            )
+
+        corner_objs = np.array([c.objectives for c in self.corners])  # (N, N)
+
+        # Normal to the hyperplane through the N corners.
+        # Translate to origin using the first corner, then find the null space
+        # of the matrix whose rows are the translated corner vectors.
+        p0 = corner_objs[0]
+        vecs = corner_objs[1:] - p0  # (N-1, N)
+
+        if n_corners == 2:
+            # 2D: rotate the single vector 90 degrees.
+            v = vecs[0]
+            normal = np.array([-v[1], v[0]], dtype=float)
+        else:
+            # General: last right singular vector spans the null space.
+            _, _, vt = linalg.svd(vecs)
+            normal = vt[-1].astype(float)
+
+        norm = float(np.linalg.norm(normal))
+        if norm == 0.0:
+            raise ValueError("Corner points are degenerate (all identical).")
+        normal /= norm
+
+        distances = np.array(
+            [abs(float(np.dot(p.objectives - p0, normal))) for p in self.points]
+        )
+        return self.points[int(distances.argmax())]
+
+
+class MultiObjectiveOptimizer(ABC):
+    """Abstract base class for multi-objective Pareto frontier tracing.
+
+    To use this class, subclass it and implement:
+
+    - :meth:`solve_with_bounds` — minimize the primary objective subject to
+      upper bounds on each auxiliary objective.
+    - :meth:`minimize_objective` — minimize a single objective with no bounds
+      on the others.
+    - :meth:`evaluate_objectives` — return all N objective values at a point.
+
+    Then call :meth:`trace` to sweep over a uniform grid of auxiliary bounds
+    and collect the resulting Pareto-optimal points.
+
+    Parameters
+    ----------
+    primary_objective : int, default=0
+        Index into the vector returned by :meth:`evaluate_objectives` that
+        identifies the objective to minimize during the frontier sweep. All
+        other objectives become auxiliary and receive parametric upper bounds.
+
+    """
+
+    def __init__(self, primary_objective: int = 0) -> None:
+        self.primary_objective = primary_objective
+
+    @abstractmethod
+    def solve_with_bounds(
+        self, bounds: npt.NDArray[np.float64]
+    ) -> InteriorPointMethodResult:
+        """Minimize the primary objective subject to auxiliary upper bounds.
+
+        Parameters
+        ----------
+        bounds : array of shape (N-1,)
+            ``bounds[j]`` is the upper bound imposed on auxiliary objective
+            ``j`` (in the order objectives appear in :meth:`evaluate_objectives`,
+            skipping the primary).
+
+        Returns
+        -------
+        InteriorPointMethodResult
+
+        """
+        ...
+
+    @abstractmethod
+    def minimize_objective(
+        self, objective_index: int
+    ) -> InteriorPointMethodResult:
+        """Minimize a single objective with no bounds on the others.
+
+        Used by :meth:`trace` to compute the N corner points of the frontier
+        and to auto-detect the sweep range for each auxiliary objective.
+
+        Parameters
+        ----------
+        objective_index : int
+            Index into the vector returned by :meth:`evaluate_objectives`.
+
+        Returns
+        -------
+        InteriorPointMethodResult
+
+        """
+        ...
+
+    @abstractmethod
+    def evaluate_objectives(
+        self, x: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Return all N objective values at decision variable ``x``.
+
+        Parameters
+        ----------
+        x : array
+            Decision variable.
+
+        Returns
+        -------
+        array of shape (N,)
+            Objective values. The element at index ``self.primary_objective``
+            is the primary objective; all others are auxiliary.
+
+        """
+        ...
+
+    def trace(self, num_points: int = 50) -> FrontierResults:
+        """Trace the Pareto frontier over a uniform grid.
+
+        Algorithm
+        ---------
+        1. Call :meth:`minimize_objective` for every objective to get N corner
+           points and auto-detect the sweep range for each auxiliary.
+        2. Build a uniform grid of ``num_points`` values per auxiliary dimension
+           spanning ``[bounds_min, bounds_max]``.
+        3. For each grid point, call :meth:`solve_with_bounds`; silently skip
+           any point that raises :class:`~cvxium.OptimizationError` or
+           :class:`~cvxium.ProblemInfeasibleError`.
+        4. Return all successfully evaluated points together with the corners.
+
+        Parameters
+        ----------
+        num_points : int, default=50
+            Number of grid points along each auxiliary-objective dimension.
+            Total solves is at most ``N * num_points^(N-1)`` where ``N`` is
+            the number of objectives.
+
+        Returns
+        -------
+        FrontierResults
+
+        """
+        # --- Step 1: compute corner points ---
+        primary_ipm = self.minimize_objective(self.primary_objective)
+        primary_objs = self.evaluate_objectives(primary_ipm.solution)
+        n_objectives = len(primary_objs)
+
+        if n_objectives < 2:
+            raise ValueError(
+                f"Need at least 2 objectives; evaluate_objectives returned "
+                f"{n_objectives} value(s)."
+            )
+
+        n_aux = n_objectives - 1
+        aux_indices = [i for i in range(n_objectives) if i != self.primary_objective]
+
+        primary_corner = FrontierPoint(
+            objectives=primary_objs,
+            solution=primary_ipm.solution.copy(),
+            bounds=np.full(n_aux, np.inf),
+            ipm_result=primary_ipm,
+        )
+
+        aux_corners: list[FrontierPoint] = []
+        for aux_idx in aux_indices:
+            try:
+                ipm = self.minimize_objective(aux_idx)
+                objs = self.evaluate_objectives(ipm.solution)
+                aux_corners.append(
+                    FrontierPoint(
+                        objectives=objs,
+                        solution=ipm.solution.copy(),
+                        bounds=np.full(n_aux, np.inf),
+                        ipm_result=ipm,
+                    )
+                )
+            except (OptimizationError, ProblemInfeasibleError):
+                pass
+
+        corners: list[FrontierPoint] = [primary_corner, *aux_corners]
+
+        # --- Step 2: auto-detect sweep range ---
+        # bounds_max[j] = value of auxiliary j at the primary minimum
+        bounds_max = np.array([float(primary_objs[i]) for i in aux_indices])
+
+        # bounds_min[j] = value of auxiliary j at its own minimum (corner j+1)
+        # Fall back to bounds_max if that corner failed (will yield a degenerate
+        # one-point sweep, which trace() handles gracefully by returning corners).
+        bounds_min = bounds_max.copy()
+        for j, aux_corner in enumerate(aux_corners):
+            bounds_min[j] = float(aux_corner.objectives[aux_indices[j]])
+
+        # Ensure min <= max (swap if objectives are oriented the other way).
+        for j in range(n_aux):
+            if bounds_min[j] > bounds_max[j]:
+                bounds_min[j], bounds_max[j] = bounds_max[j], bounds_min[j]
+
+        # --- Step 3: grid sweep ---
+        grids = [
+            np.linspace(bounds_min[j], bounds_max[j], num_points)
+            for j in range(n_aux)
+        ]
+
+        points: list[FrontierPoint] = list(corners)
+
+        for bounds_combo in itertools_product(*grids):
+            bounds = np.array(bounds_combo)
+            try:
+                ipm = self.solve_with_bounds(bounds)
+                objs = self.evaluate_objectives(ipm.solution)
+                points.append(
+                    FrontierPoint(
+                        objectives=objs,
+                        solution=ipm.solution.copy(),
+                        bounds=bounds.copy(),
+                        ipm_result=ipm,
+                    )
+                )
+            except (OptimizationError, ProblemInfeasibleError):
+                continue
+
+        return FrontierResults(
+            points=points,
+            corners=corners,
+            primary_objective=self.primary_objective,
+        )
+
+
+__all__: list[str] = [
+    "FrontierPoint",
+    "FrontierResults",
+    "MultiObjectiveOptimizer",
+]

--- a/cvxium/multi_objective.py
+++ b/cvxium/multi_objective.py
@@ -43,14 +43,23 @@ class FrontierResults:
     Parameters
     ----------
     points : list[FrontierPoint]
-        All successfully evaluated points, including the corner points.
+        All successfully evaluated points, including the corner points,
+        deduplicated by objective vector.
     corners : list[FrontierPoint]
         The N corner points, one per objective. ``corners[0]`` minimizes the
         primary objective; ``corners[k]`` minimizes the k-th auxiliary objective
         (in the order they appear in ``evaluate_objectives``, skipping the
-        primary).
+        primary). If a corner solve failed, fewer than N corners are stored and
+        :meth:`knee` will raise.
     primary_objective : int
         Index of the primary objective.
+    n_attempted : int
+        Number of grid points where :meth:`~MultiObjectiveOptimizer.solve_with_bounds`
+        was called.
+    n_skipped : int
+        Number of grid points that were skipped because the solver raised
+        :class:`~cvxium.OptimizationError` or
+        :class:`~cvxium.ProblemInfeasibleError`.
 
     """
 
@@ -59,10 +68,14 @@ class FrontierResults:
         points: list[FrontierPoint],
         corners: list[FrontierPoint],
         primary_objective: int,
+        n_attempted: int,
+        n_skipped: int,
     ) -> None:
         self.points = points
         self.corners = corners
         self.primary_objective = primary_objective
+        self.n_attempted = n_attempted
+        self.n_skipped = n_skipped
 
     def knee(self) -> FrontierPoint:
         """Return the frontier point maximally distant from the corner hyperplane.
@@ -72,6 +85,14 @@ class FrontierResults:
         (where N is the number of objectives). For two objectives this reduces
         to the standard max-chord-distance method.
 
+        The reference hyperplane is constructed by translating the corner points
+        so that ``corners[0]`` is at the origin, then finding the null-space of
+        the matrix whose rows are the remaining translated corners via SVD. This
+        requires the N corner points to be **affinely independent**: if they are
+        (nearly) coplanar in objective space the normal will be numerically
+        unreliable. The check ``norm == 0`` catches exact degeneracy; near-
+        degeneracy is not currently detected.
+
         Returns
         -------
         FrontierPoint
@@ -79,38 +100,46 @@ class FrontierResults:
         Raises
         ------
         ValueError
-            If fewer than 2 corner points are available or the frontier is empty.
+            If the frontier is empty, if fewer than N corners are available
+            (where N = number of objectives inferred from the first point), or
+            if the corner points are degenerate.
 
         """
         if not self.points:
             raise ValueError("No frontier points to evaluate.")
 
+        n_objectives = len(self.points[0].objectives)
         n_corners = len(self.corners)
+
         if n_corners < 2:
             raise ValueError(
                 f"Need at least 2 corner points for knee calculation; got {n_corners}."
+            )
+        if n_corners != n_objectives:
+            raise ValueError(
+                f"knee() requires exactly one corner per objective "
+                f"(N={n_objectives}), but {n_corners} corner(s) are available. "
+                f"This typically means one or more minimize_objective() calls "
+                f"failed during trace()."
             )
 
         corner_objs = np.array([c.objectives for c in self.corners])  # (N, N)
 
         # Normal to the hyperplane through the N corners.
         # Translate to origin using the first corner, then find the null space
-        # of the matrix whose rows are the translated corner vectors.
+        # of the (N-1) x N matrix whose rows are the translated corner vectors.
+        # For N objectives, that matrix has exactly one null-space direction.
         p0 = corner_objs[0]
         vecs = corner_objs[1:] - p0  # (N-1, N)
 
-        if n_corners == 2:
-            # 2D: rotate the single vector 90 degrees.
-            v = vecs[0]
-            normal = np.array([-v[1], v[0]], dtype=float)
-        else:
-            # General: last right singular vector spans the null space.
-            _, _, vt = linalg.svd(vecs)
-            normal = vt[-1].astype(float)
+        _, _, vt = linalg.svd(vecs, full_matrices=True)
+        normal = vt[-1].astype(float)  # last right singular vector = null space
 
         norm = float(np.linalg.norm(normal))
         if norm == 0.0:
-            raise ValueError("Corner points are degenerate (all identical).")
+            raise ValueError(
+                "Corner points are degenerate (all identical or collinear)."
+            )
         normal /= norm
 
         distances = np.array(
@@ -216,20 +245,29 @@ class MultiObjectiveOptimizer(ABC):
         3. For each grid point, call :meth:`solve_with_bounds`; silently skip
            any point that raises :class:`~cvxium.OptimizationError` or
            :class:`~cvxium.ProblemInfeasibleError`.
-        4. Return all successfully evaluated points together with the corners.
+        4. Deduplicate by objective vector (within ``1e-8`` absolute tolerance),
+           then return all unique points together with the corners.
 
         Parameters
         ----------
         num_points : int, default=50
             Number of grid points along each auxiliary-objective dimension.
-            Total solves is at most ``N * num_points^(N-1)`` where ``N`` is
+            Total solves is at most ``N + num_points^(N-1)`` where ``N`` is
             the number of objectives.
 
         Returns
         -------
         FrontierResults
 
+        Raises
+        ------
+        ValueError
+            If ``num_points < 1`` or fewer than 2 objectives are detected.
+
         """
+        if num_points < 1:
+            raise ValueError(f"num_points must be >= 1; got {num_points}.")
+
         # --- Step 1: compute corner points ---
         primary_ipm = self.minimize_objective(self.primary_objective)
         primary_objs = self.evaluate_objectives(primary_ipm.solution)
@@ -273,9 +311,9 @@ class MultiObjectiveOptimizer(ABC):
         # bounds_max[j] = value of auxiliary j at the primary minimum
         bounds_max = np.array([float(primary_objs[i]) for i in aux_indices])
 
-        # bounds_min[j] = value of auxiliary j at its own minimum (corner j+1)
-        # Fall back to bounds_max if that corner failed (will yield a degenerate
-        # one-point sweep, which trace() handles gracefully by returning corners).
+        # bounds_min[j] = value of auxiliary j at its own minimum (corner j+1).
+        # Fall back to bounds_max if that corner failed (yields a degenerate
+        # one-point sweep; trace() still returns the corners gracefully).
         bounds_min = bounds_max.copy()
         for j, aux_corner in enumerate(aux_corners):
             bounds_min[j] = float(aux_corner.objectives[aux_indices[j]])
@@ -290,10 +328,14 @@ class MultiObjectiveOptimizer(ABC):
             np.linspace(bounds_min[j], bounds_max[j], num_points) for j in range(n_aux)
         ]
 
+        # Corners are prepended so they survive deduplication (first-seen wins).
         points: list[FrontierPoint] = list(corners)
+        n_attempted = 0
+        n_skipped = 0
 
         for bounds_combo in itertools_product(*grids):
             bounds = np.array(bounds_combo)
+            n_attempted += 1
             try:
                 ipm = self.solve_with_bounds(bounds)
                 objs = self.evaluate_objectives(ipm.solution)
@@ -306,12 +348,22 @@ class MultiObjectiveOptimizer(ABC):
                     )
                 )
             except (OptimizationError, ProblemInfeasibleError):
-                continue
+                n_skipped += 1
+
+        # --- Step 4: deduplicate by objective vector ---
+        unique: list[FrontierPoint] = []
+        for p in points:
+            if not any(
+                np.allclose(p.objectives, q.objectives, atol=1e-8) for q in unique
+            ):
+                unique.append(p)
 
         return FrontierResults(
-            points=points,
+            points=unique,
             corners=corners,
             primary_objective=self.primary_objective,
+            n_attempted=n_attempted,
+            n_skipped=n_skipped,
         )
 
 

--- a/cvxium/numerical_helpers.py
+++ b/cvxium/numerical_helpers.py
@@ -99,7 +99,8 @@ def solve_rank_one_update(
 
     Solves a linear system of equations where H = A + d * kappa * kappa^T, where A has
     some special structure that makes it easy to solve A * y = c, and kappa is a vector.
-    Thus, H is a rank-one update to A. When d is omitted, H = A + kappa * kappa^T.
+    Thus, H is a rank-one update (d > 0) or downdate (d < 0) to A. When d is omitted,
+    H = A + kappa * kappa^T.
 
     Parameters
     ----------
@@ -113,7 +114,8 @@ def solve_rank_one_update(
         Additional arguments will be passed via **kwargs. A_solve should be able to
         accept multiple right-hand-sides.
      d : float, optional
-        Positive scalar weight on the rank-one term. Defaults to 1.0.
+        Scalar weight on the rank-one term. Positive means update, negative means
+        downdate. Must be nonzero. Defaults to 1.0.
      kwargs
         Extra arguments to pass to A_solve.
 
@@ -124,13 +126,20 @@ def solve_rank_one_update(
 
     Notes
     -----
-    Let H = A + d * kappa * kappa^T, where kappa is a vector of length M and d > 0.
-    By the Sherman-Morrison formula, the Schur complement denominator becomes
-    1/d + kappa^T * A^{-1} * kappa. We can solve H * x = b in O(2*t + 6*M) time,
-    where t is the time needed to solve A*y = c, as follows:
+    Let H = A + d * kappa * kappa^T, where kappa is a vector of length M. By the
+    Sherman-Morrison formula, the Schur complement is the scalar
+    G = 1/d + kappa^T * A^{-1} * kappa. The formula is valid whenever G != 0.
+
+    When A is positive definite, the sign of G reveals H's definiteness:
+     - d > 0 (update): G > 0 always; H is PD.
+     - d < 0 (downdate): G < 0 -> H is PD; G = 0 -> H is singular;
+       G > 0 -> H is indefinite (downdate too large).
+
+    We raise NewtonStepError if H is not positive definite (G = 0 or G has the
+    wrong sign for the sign of d). The solve itself is O(2*t + 6*M):
        1. Solve A * x' = b (t time).
        2. Solve A * xi = kappa (t time).
-       3. Calculate x as x' - ((kappa^T * x') / (1/d + kappa^T * xi)) * xi.
+       3. Calculate x as x' - ((kappa^T * x') / G) * xi.
     In total that's 2*t, 3M multiplies, and 3M adds.
 
 
@@ -144,13 +153,21 @@ def solve_rank_one_update(
     else:
         raise ValueError("b must be either a 1D or 2D NumPy array.")
 
-    if d is not None and d <= 0:
-        raise ValueError("d must be strictly positive.")
+    if d is not None and d == 0:
+        raise ValueError("d must be nonzero.")
 
     x_prime = A_solve(b, **kwargs)
     xi = A_solve(kappa, **kwargs)
     schur_diag = 1.0 / d if d is not None else 1.0
-    den = 1.0 / (schur_diag + np.dot(kappa, xi))
+    G = schur_diag + np.dot(kappa, xi)
+
+    # For a downdate (d < 0), H is PD only when G < 0.
+    # G > 0 with d < 0 means the downdate is too large; H is indefinite.
+    # G = 0 means H is singular.
+    if d is not None and d < 0 and G >= 0:
+        raise NewtonStepError("H is not positive definite")
+
+    den = 1.0 / G
 
     if b.ndim == 1:
         return x_prime - (np.dot(kappa, x_prime) * den) * xi
@@ -171,8 +188,8 @@ def solve_rank_p_update(
 
     Solves a linear system of equations where H = A + kappa @ D @ kappa^T, where A has
     some special structure that makes it easy to solve A * y = c, kappa is rank p, and
-    D = diag(d) with strictly positive d. Thus, H is a rank-p update to A. When d is
-    omitted, D = I and H = A + kappa @ kappa^T.
+    D = diag(d). Thus, H is a rank-p update (d > 0) or downdate (d < 0) to A, or a mix
+    of both. When d is omitted, D = I and H = A + kappa @ kappa^T.
 
     Parameters
     ----------
@@ -186,7 +203,8 @@ def solve_rank_p_update(
         Additional arguments will be passed via **kwargs. A_solve should be able to
         accept multiple right-hand-sides.
      d : npt.NDArray[np.float64], optional
-        Strictly positive vector of length p defining D = diag(d). Defaults to all ones.
+        Nonzero vector of length p defining D = diag(d). Positive entries are updates,
+        negative entries are downdates. Defaults to all ones.
      kwargs
         Extra arguments to pass to A_solve.
 
@@ -197,28 +215,28 @@ def solve_rank_p_update(
 
     Notes
     -----
-    Let H = A + kappa @ D @ kappa^T, where kappa is an M-by-p matrix and D = diag(d)
-    with d > 0. By the Woodbury identity, the Schur complement matrix is
-    G = D^{-1} + kappa^T @ A^{-1} @ kappa. We can solve H * x = b in
-    O((p + q) * t + 2 * M * p * (p + 2 * q)) time, where t is the number of flops
-    needed to solve A*y = c, as follows:
-       1. Solve A * xi = kappa. This is p solves with A (at most p * t flops; by passing
-          multiple right hand sides it may be less than p * t flops, since we avoid
-          duplicating calculations unnecessarily). xi is M-by-p.
-       2. Calculate G = D^{-1} + kappa^T * xi (p^2 * M multiplies and p^2 * (M - 1) + p
-          adds, or O(2 * M * p^2) flops). G is p-by-p.
-       3. Compute the Cholesky factorization of G (1/3 * p^3 flops).
-       4. Solve A * x' = b (When there are q right-hand-sides, this is at most q * t
-          flops). x' is M-by-q.
-       5. Calculate z = kappa^T * x' (p * q * M multiplies and p * q * (M - 1) adds or
-          2 * M * p * q flops). z is p-by-q.
-       6. Solve G * y = z, using the Cholesky factorization. It takes 2 * p^2 * q time
-          to solve for y. y is p-by-q.
-       7. Calculate x as x' - xi @ y. This is M * p * q multiplies and M * p * q adds or
-          2 * M * p * q flops.
-    In total that's (p + q) * t + 2 * M * p^2 + 4 * M * p * q + (1/3) * p^3 + 2 * p^2 * q
-    flops, or (p + q) * t + 2 * M * p * (p + 2 * q) + p^2 * ((1/3) * p + 2 * q) or
-    (p + q) * t + 2 * M * p * (p + 2 * q) when p and q << M.
+    Let H = A + kappa @ D @ kappa^T, where kappa is an M-by-p matrix and D = diag(d).
+    By the Woodbury identity, the Schur complement matrix is
+    G = D^{-1} + kappa^T @ A^{-1} @ kappa. The formula is valid whenever G is invertible.
+
+    When A is positive definite, the sign structure of d determines how we check H's
+    positive definiteness via G:
+     - All d > 0 (pure update): G is always PD; H is always PD. Checked via Cholesky(G).
+     - All d < 0 (pure downdate): H is PD iff G is negative definite (ND), i.e. -G is
+       PD. Checked via Cholesky(-G). If -G is not PD, H is indefinite.
+     - Mixed d: PD status requires full eigenvalue analysis; we check only invertibility
+       via LU, and the solve is algebraically correct whenever G is invertible.
+
+    We can solve H * x = b in O((p + q) * t + 2 * M * p * (p + 2 * q)) time, where t is
+    the number of flops needed to solve A*y = c, as follows:
+       1. Solve A * xi = kappa. xi is M-by-p.
+       2. Calculate G = D^{-1} + kappa^T * xi. G is p-by-p.
+       3. Factor G (Cholesky or LU depending on sign of d).
+       4. Solve A * x' = b. x' is M-by-q.
+       5. Calculate z = kappa^T * x'. z is p-by-q.
+       6. Solve G * y = z. y is p-by-q.
+       7. Calculate x = x' - xi @ y.
+    In total that's (p + q) * t + 2 * M * p * (p + 2 * q) when p and q << M.
 
     """
     if b.ndim not in (1, 2):
@@ -232,8 +250,8 @@ def solve_rank_p_update(
     if d is not None:
         if d.shape != (p,):
             raise ValueError("d must be a 1D array of length p (kappa.shape[1]).")
-        if not np.all(d > 0):
-            raise ValueError("d must have strictly positive entries.")
+        if not np.all(d != 0):
+            raise ValueError("All entries of d must be nonzero.")
 
     # xi is M-by-p
     xi = A_solve(kappa, **kwargs)
@@ -243,17 +261,34 @@ def solve_rank_p_update(
         G = np.diag(1.0 / d) + kappa.T @ xi
     else:
         G = np.eye(p) + kappa.T @ xi
-    try:
-        c, lower = linalg.cho_factor(G, lower=True)
-    except np.linalg.LinAlgError:
-        raise NewtonStepError("H is not positive definite") from None
 
     # q RHS -> x_prime is M-by-q
     x_prime = A_solve(b, **kwargs)
     z = kappa.T @ x_prime  # p-by-q
 
-    # y is p-by-q
-    y = linalg.cho_solve((c, lower), z)
+    if d is None or np.all(d > 0):
+        # Pure update: G is always PD when A is PD. Use Cholesky.
+        try:
+            c, lower = linalg.cho_factor(G, lower=True)
+        except np.linalg.LinAlgError:
+            raise NewtonStepError("H is not positive definite") from None
+        y = linalg.cho_solve((c, lower), z)
+    elif np.all(d < 0):
+        # Pure downdate: H is PD iff G is ND, i.e. -G is PD.
+        try:
+            c, lower = linalg.cho_factor(-G, lower=True)
+        except np.linalg.LinAlgError:
+            raise NewtonStepError("H is not positive definite") from None
+        # G^{-1} z = -((-G)^{-1} z)
+        y = -linalg.cho_solve((c, lower), z)
+    else:
+        # Mixed signs: check invertibility only via LU.
+        try:
+            lu, piv = linalg.lu_factor(G)
+            y = linalg.lu_solve((lu, piv), z)
+        except np.linalg.LinAlgError:
+            raise NewtonStepError("H is not positive definite") from None
+
     return x_prime - xi @ y
 
 
@@ -761,8 +796,8 @@ def multiply_rank_one_update(
 
     Computes the matrix-vector (or matrix-matrix) product H @ y where
     H = A + d * kappa * kappa^T, where A has some special structure that makes it easy to
-    compute A @ z, and kappa is a vector. Thus, H is a rank-one update to A. When d is
-    omitted, H = A + kappa * kappa^T.
+    compute A @ z, and kappa is a vector. Thus, H is a rank-one update (d > 0) or downdate
+    (d < 0) to A. When d is omitted, H = A + kappa * kappa^T.
 
     Parameters
     ----------
@@ -776,7 +811,8 @@ def multiply_rank_one_update(
         Additional arguments will be passed via **kwargs. A_multiply should be able to
         accept multiple right-hand-sides.
      d : float, optional
-        Positive scalar weight on the rank-one term. Defaults to 1.0.
+        Scalar weight on the rank-one term. Positive means update, negative means
+        downdate. Defaults to 1.0.
      kwargs
         Extra arguments to pass to A_multiply.
 
@@ -787,9 +823,9 @@ def multiply_rank_one_update(
 
     Notes
     -----
-    Let H = A + d * kappa * kappa^T, where kappa is a vector of length M and d > 0. We
-    compute H @ y = A @ y + d * kappa * (kappa^T @ y) in O(t + 3*M) time, where t is
-    the time needed to compute A @ z:
+    Let H = A + d * kappa * kappa^T, where kappa is a vector of length M. We compute
+    H @ y = A @ y + d * kappa * (kappa^T @ y) in O(t + 3*M) time, where t is the time
+    needed to compute A @ z:
        1. Compute A @ y (t time).
        2. Compute kappa^T @ y (2*M flops).
        3. Add d * kappa * (kappa^T @ y) (2*M flops).
@@ -804,9 +840,6 @@ def multiply_rank_one_update(
             raise ValueError("Number of rows in y must match length of kappa.")
     else:
         raise ValueError("y must be either a 1D or 2D NumPy array.")
-
-    if d is not None and d <= 0:
-        raise ValueError("d must be strictly positive.")
 
     scale = d if d is not None else 1.0
     Ay = A_multiply(y, **kwargs)
@@ -827,8 +860,9 @@ def multiply_rank_p_update(
 
     Computes the matrix-vector (or matrix-matrix) product H @ y where
     H = A + kappa @ D @ kappa^T, where A has some special structure, kappa is an M-by-p
-    matrix, and D = diag(d) with strictly positive d. Thus, H is a rank-p update to A.
-    When d is omitted, D = I and H = A + kappa @ kappa^T.
+    matrix, and D = diag(d). Thus, H is a rank-p update (d > 0) or downdate (d < 0) to A.
+    Mixed signs in d are also permitted. When d is omitted, D = I and H = A + kappa @
+    kappa^T.
 
     Parameters
     ----------
@@ -842,7 +876,8 @@ def multiply_rank_p_update(
         Additional arguments will be passed via **kwargs. A_multiply should be able to
         accept multiple right-hand-sides.
      d : npt.NDArray[np.float64], optional
-        Strictly positive vector of length p defining D = diag(d). Defaults to all ones.
+        Vector of length p defining D = diag(d). Positive entries are updates, negative
+        entries are downdates. Defaults to all ones.
      kwargs
         Extra arguments to pass to A_multiply.
 
@@ -853,9 +888,9 @@ def multiply_rank_p_update(
 
     Notes
     -----
-    Let H = A + kappa @ D @ kappa^T, where kappa is an M-by-p matrix and D = diag(d)
-    with d > 0. We compute H @ y = A @ y + kappa @ (D @ (kappa^T @ y)) in O(t + 4*M*p)
-    time, where t is the time needed to compute A @ z:
+    Let H = A + kappa @ D @ kappa^T, where kappa is an M-by-p matrix and D = diag(d).
+    We compute H @ y = A @ y + kappa @ (D @ (kappa^T @ y)) in O(t + 4*M*p) time, where
+    t is the time needed to compute A @ z:
        1. Compute A @ y (t time).
        2. Compute kappa^T @ y (2*M*p flops for a vector y).
        3. Scale by D: d * (kappa^T @ y) (p flops).
@@ -871,11 +906,8 @@ def multiply_rank_p_update(
 
     p = kappa.shape[1]
 
-    if d is not None:
-        if d.shape != (p,):
-            raise ValueError("d must be a 1D array of length p (kappa.shape[1]).")
-        if not np.all(d > 0):
-            raise ValueError("d must have strictly positive entries.")
+    if d is not None and d.shape != (p,):
+        raise ValueError("d must be a 1D array of length p (kappa.shape[1]).")
 
     kkt = kappa.T @ y  # shape: (p,) or (p, q)
     if d is not None:

--- a/cvxium/numerical_helpers.py
+++ b/cvxium/numerical_helpers.py
@@ -92,13 +92,14 @@ def solve_rank_one_update(
     b: npt.NDArray[np.float64],
     kappa: npt.NDArray[np.float64],
     A_solve: Callable[..., npt.NDArray[np.float64]],
+    d: float | None = None,
     **kwargs: Any,
 ) -> npt.NDArray[np.float64]:
     """Solve H * x = b.
 
-    Solves a linear system of equations where H = A + kappa * kappa^T, where A has some
-    special structure that makes it easy to solve A * y = c, and kappa is a vector.
-    Thus, H is a rank-one update to A.
+    Solves a linear system of equations where H = A + d * kappa * kappa^T, where A has
+    some special structure that makes it easy to solve A * y = c, and kappa is a vector.
+    Thus, H is a rank-one update to A. When d is omitted, H = A + kappa * kappa^T.
 
     Parameters
     ----------
@@ -111,6 +112,8 @@ def solve_rank_one_update(
         A function that solves A * y = c. The first argument to A_solve will be c.
         Additional arguments will be passed via **kwargs. A_solve should be able to
         accept multiple right-hand-sides.
+     d : float, optional
+        Positive scalar weight on the rank-one term. Defaults to 1.0.
      kwargs
         Extra arguments to pass to A_solve.
 
@@ -121,15 +124,13 @@ def solve_rank_one_update(
 
     Notes
     -----
-    Let H = A + kappa * kappa^T, where kappa is a vector of length M. We can solve
-    H * x = b in O(2*t + 6*M) time, where t is the time needed to solve A*y = c, as
-    follows:
+    Let H = A + d * kappa * kappa^T, where kappa is a vector of length M and d > 0.
+    By the Sherman-Morrison formula, the Schur complement denominator becomes
+    1/d + kappa^T * A^{-1} * kappa. We can solve H * x = b in O(2*t + 6*M) time,
+    where t is the time needed to solve A*y = c, as follows:
        1. Solve A * x' = b (t time).
        2. Solve A * xi = kappa (t time).
-       3. Calculate x as x' - ((kappa^T * x') / (1 + kappa^T * xi)) * xi. This is 2 dot
-          products (each involving M multiplies and M-1 adds) plus M multiplies and M
-          subtractions, or O(3M) multiplies plus O(3M) adds, plus a single add and a
-          division.
+       3. Calculate x as x' - ((kappa^T * x') / (1/d + kappa^T * xi)) * xi.
     In total that's 2*t, 3M multiplies, and 3M adds.
 
 
@@ -143,9 +144,13 @@ def solve_rank_one_update(
     else:
         raise ValueError("b must be either a 1D or 2D NumPy array.")
 
+    if d is not None and d <= 0:
+        raise ValueError("d must be strictly positive.")
+
     x_prime = A_solve(b, **kwargs)
     xi = A_solve(kappa, **kwargs)
-    den = 1.0 / (1.0 + np.dot(kappa, xi))
+    schur_diag = (1.0 / d if d is not None else 1.0)
+    den = 1.0 / (schur_diag + np.dot(kappa, xi))
 
     if b.ndim == 1:
         return x_prime - (np.dot(kappa, x_prime) * den) * xi
@@ -159,13 +164,15 @@ def solve_rank_p_update(
     b: npt.NDArray[np.float64],
     kappa: npt.NDArray[np.float64],
     A_solve: Callable[..., npt.NDArray[np.float64]],
+    d: npt.NDArray[np.float64] | None = None,
     **kwargs: Any,
 ) -> npt.NDArray[np.float64]:
     """Solve H * x = b.
 
-    Solves a linear system of equations where H = A + kappa * kappa^T, where A has some
-    special structure that makes it easy to solve A * y = c, and kappa is rank p. Thus,
-    H is a rank-p update to A.
+    Solves a linear system of equations where H = A + kappa @ D @ kappa^T, where A has
+    some special structure that makes it easy to solve A * y = c, kappa is rank p, and
+    D = diag(d) with strictly positive d. Thus, H is a rank-p update to A. When d is
+    omitted, D = I and H = A + kappa @ kappa^T.
 
     Parameters
     ----------
@@ -173,11 +180,13 @@ def solve_rank_p_update(
         Right hand side. Can be either a vector or a matrix, in which case we solve the
         system for each column of b.
      kappa : npt.NDArray[np.float64]
-        Rank-p component of H.
+        Rank-p component of H, an M-by-p matrix.
      A_solve : Callable
         A function that solves A * y = c. The first argument to A_solve will be c.
         Additional arguments will be passed via **kwargs. A_solve should be able to
         accept multiple right-hand-sides.
+     d : npt.NDArray[np.float64], optional
+        Strictly positive vector of length p defining D = diag(d). Defaults to all ones.
      kwargs
         Extra arguments to pass to A_solve.
 
@@ -188,14 +197,16 @@ def solve_rank_p_update(
 
     Notes
     -----
-    Let H = A + kappa * kappa^T, where kappa is an M-by-p matrix. We can solve H * x = b
-    in O((p + q) * t + 2 * M * p * (p + 2 * q)) time, where t is the number of flops
+    Let H = A + kappa @ D @ kappa^T, where kappa is an M-by-p matrix and D = diag(d)
+    with d > 0. By the Woodbury identity, the Schur complement matrix is
+    G = D^{-1} + kappa^T @ A^{-1} @ kappa. We can solve H * x = b in
+    O((p + q) * t + 2 * M * p * (p + 2 * q)) time, where t is the number of flops
     needed to solve A*y = c, as follows:
        1. Solve A * xi = kappa. This is p solves with A (at most p * t flops; by passing
           multiple right hand sides it may be less than p * t flops, since we avoid
           duplicating calculations unnecessarily). xi is M-by-p.
-       2. Calculate G = I + kappa^T * xi (p^2 * M multiplies and p^2 * (M - 1) + p adds,
-          or O(2 * M * p^2) flops). G is p-by-p.
+       2. Calculate G = D^{-1} + kappa^T * xi (p^2 * M multiplies and p^2 * (M - 1) + p
+          adds, or O(2 * M * p^2) flops). G is p-by-p.
        3. Compute the Cholesky factorization of G (1/3 * p^3 flops).
        4. Solve A * x' = b (When there are q right-hand-sides, this is at most q * t
           flops). x' is M-by-q.
@@ -216,11 +227,22 @@ def solve_rank_p_update(
     if b.shape[0] != kappa.shape[0]:
         raise ValueError("Number of rows in beta must match length of kappa.")
 
+    p = kappa.shape[1]
+
+    if d is not None:
+        if d.shape != (p,):
+            raise ValueError("d must be a 1D array of length p (kappa.shape[1]).")
+        if not np.all(d > 0):
+            raise ValueError("d must have strictly positive entries.")
+
     # xi is M-by-p
     xi = A_solve(kappa, **kwargs)
 
-    # G is p-by-p
-    G = np.eye(kappa.shape[1]) + kappa.T @ xi
+    # G is p-by-p; G = D^{-1} + kappa^T @ xi
+    if d is not None:
+        G = np.diag(1.0 / d) + kappa.T @ xi
+    else:
+        G = np.eye(p) + kappa.T @ xi
     try:
         c, lower = linalg.cho_factor(G, lower=True)
     except np.linalg.LinAlgError:
@@ -732,13 +754,15 @@ def multiply_rank_one_update(
     y: npt.NDArray[np.float64],
     kappa: npt.NDArray[np.float64],
     A_multiply: Callable[..., npt.NDArray[np.float64]],
+    d: float | None = None,
     **kwargs: Any,
 ) -> npt.NDArray[np.float64]:
     """Compute H @ y.
 
     Computes the matrix-vector (or matrix-matrix) product H @ y where
-    H = A + kappa * kappa^T, where A has some special structure that makes it easy to
-    compute A @ z, and kappa is a vector. Thus, H is a rank-one update to A.
+    H = A + d * kappa * kappa^T, where A has some special structure that makes it easy to
+    compute A @ z, and kappa is a vector. Thus, H is a rank-one update to A. When d is
+    omitted, H = A + kappa * kappa^T.
 
     Parameters
     ----------
@@ -751,6 +775,8 @@ def multiply_rank_one_update(
         A function that computes A @ z. The first argument to A_multiply will be z.
         Additional arguments will be passed via **kwargs. A_multiply should be able to
         accept multiple right-hand-sides.
+     d : float, optional
+        Positive scalar weight on the rank-one term. Defaults to 1.0.
      kwargs
         Extra arguments to pass to A_multiply.
 
@@ -761,12 +787,12 @@ def multiply_rank_one_update(
 
     Notes
     -----
-    Let H = A + kappa * kappa^T, where kappa is a vector of length M. We compute
-    H @ y = A @ y + kappa * (kappa^T @ y) in O(t + 3*M) time, where t is the time
-    needed to compute A @ z:
+    Let H = A + d * kappa * kappa^T, where kappa is a vector of length M and d > 0. We
+    compute H @ y = A @ y + d * kappa * (kappa^T @ y) in O(t + 3*M) time, where t is
+    the time needed to compute A @ z:
        1. Compute A @ y (t time).
        2. Compute kappa^T @ y (2*M flops).
-       3. Add kappa * (kappa^T @ y) (2*M flops).
+       3. Add d * kappa * (kappa^T @ y) (2*M flops).
     In total that's t + 4*M flops.
 
     """
@@ -779,24 +805,30 @@ def multiply_rank_one_update(
     else:
         raise ValueError("y must be either a 1D or 2D NumPy array.")
 
+    if d is not None and d <= 0:
+        raise ValueError("d must be strictly positive.")
+
+    scale = d if d is not None else 1.0
     Ay = A_multiply(y, **kwargs)
     if y.ndim == 1:
-        return Ay + kappa * np.dot(kappa, y)
+        return Ay + scale * kappa * np.dot(kappa, y)
     else:
-        return Ay + np.outer(kappa, kappa.T @ y)
+        return Ay + scale * np.outer(kappa, kappa.T @ y)
 
 
 def multiply_rank_p_update(
     y: npt.NDArray[np.float64],
     kappa: npt.NDArray[np.float64],
     A_multiply: Callable[..., npt.NDArray[np.float64]],
+    d: npt.NDArray[np.float64] | None = None,
     **kwargs: Any,
 ) -> npt.NDArray[np.float64]:
     """Compute H @ y.
 
     Computes the matrix-vector (or matrix-matrix) product H @ y where
-    H = A + kappa * kappa^T, where A has some special structure, and kappa is an M-by-p
-    matrix. Thus, H is a rank-p update to A.
+    H = A + kappa @ D @ kappa^T, where A has some special structure, kappa is an M-by-p
+    matrix, and D = diag(d) with strictly positive d. Thus, H is a rank-p update to A.
+    When d is omitted, D = I and H = A + kappa @ kappa^T.
 
     Parameters
     ----------
@@ -809,6 +841,8 @@ def multiply_rank_p_update(
         A function that computes A @ z. The first argument to A_multiply will be z.
         Additional arguments will be passed via **kwargs. A_multiply should be able to
         accept multiple right-hand-sides.
+     d : npt.NDArray[np.float64], optional
+        Strictly positive vector of length p defining D = diag(d). Defaults to all ones.
      kwargs
         Extra arguments to pass to A_multiply.
 
@@ -819,13 +853,14 @@ def multiply_rank_p_update(
 
     Notes
     -----
-    Let H = A + kappa * kappa^T, where kappa is an M-by-p matrix. We compute
-    H @ y = A @ y + kappa @ (kappa^T @ y) in O(t + 4*M*p) time, where t is the time
-    needed to compute A @ z:
+    Let H = A + kappa @ D @ kappa^T, where kappa is an M-by-p matrix and D = diag(d)
+    with d > 0. We compute H @ y = A @ y + kappa @ (D @ (kappa^T @ y)) in O(t + 4*M*p)
+    time, where t is the time needed to compute A @ z:
        1. Compute A @ y (t time).
        2. Compute kappa^T @ y (2*M*p flops for a vector y).
-       3. Add kappa @ (kappa^T @ y) (2*M*p flops).
-    In total that's t + 4*M*p flops.
+       3. Scale by D: d * (kappa^T @ y) (p flops).
+       4. Add kappa @ (D @ (kappa^T @ y)) (2*M*p flops).
+    In total that's t + 4*M*p + p flops.
 
     """
     if y.ndim not in (1, 2):
@@ -834,7 +869,21 @@ def multiply_rank_p_update(
     if y.shape[0] != kappa.shape[0]:
         raise ValueError("Number of rows in y must match number of rows in kappa.")
 
-    return A_multiply(y, **kwargs) + kappa @ (kappa.T @ y)
+    p = kappa.shape[1]
+
+    if d is not None:
+        if d.shape != (p,):
+            raise ValueError("d must be a 1D array of length p (kappa.shape[1]).")
+        if not np.all(d > 0):
+            raise ValueError("d must have strictly positive entries.")
+
+    kkt = kappa.T @ y  # shape: (p,) or (p, q)
+    if d is not None:
+        if y.ndim == 1:
+            kkt = d * kkt
+        else:
+            kkt = d[:, np.newaxis] * kkt
+    return A_multiply(y, **kwargs) + kappa @ kkt
 
 
 def multiply_block_plus_one(

--- a/cvxium/numerical_helpers.py
+++ b/cvxium/numerical_helpers.py
@@ -149,7 +149,7 @@ def solve_rank_one_update(
 
     x_prime = A_solve(b, **kwargs)
     xi = A_solve(kappa, **kwargs)
-    schur_diag = (1.0 / d if d is not None else 1.0)
+    schur_diag = 1.0 / d if d is not None else 1.0
     den = 1.0 / (schur_diag + np.dot(kappa, xi))
 
     if b.ndim == 1:

--- a/cvxium/numerical_helpers.py
+++ b/cvxium/numerical_helpers.py
@@ -127,8 +127,9 @@ def solve_rank_one_update(
     Notes
     -----
     Let H = A + d * kappa * kappa^T, where kappa is a vector of length M. By the
-    Sherman-Morrison formula, the Schur complement is the scalar
-    G = 1/d + kappa^T * A^{-1} * kappa. The formula is valid whenever G != 0.
+    Sherman-Morrison formula, the relevant scalar is:
+       G = 1/d + kappa^T * A^{-1} * kappa.
+    The formula is valid whenever G != 0.
 
     When A is positive definite, the sign of G reveals H's definiteness:
      - d > 0 (update): G > 0 always; H is PD.
@@ -149,7 +150,7 @@ def solve_rank_one_update(
             raise ValueError("b and kappa must have the same length.")
     elif b.ndim == 2:
         if b.shape[0] != kappa.shape[0]:
-            raise ValueError("Number of rows in beta must match length of kappa.")
+            raise ValueError("Number of rows in b must match length of kappa.")
     else:
         raise ValueError("b must be either a 1D or 2D NumPy array.")
 
@@ -160,6 +161,10 @@ def solve_rank_one_update(
     xi = A_solve(kappa, **kwargs)
     schur_diag = 1.0 / d if d is not None else 1.0
     G = schur_diag + np.dot(kappa, xi)
+
+    tol = 1e-12
+    if abs(G) <= tol:
+        raise NewtonStepError("H is singular or nearly singular")
 
     # For a downdate (d < 0), H is PD only when G < 0.
     # G > 0 with d < 0 means the downdate is too large; H is indefinite.
@@ -187,9 +192,9 @@ def solve_rank_p_update(
     """Solve H * x = b.
 
     Solves a linear system of equations where H = A + kappa @ D @ kappa^T, where A has
-    some special structure that makes it easy to solve A * y = c, kappa is rank p, and
-    D = diag(d). Thus, H is a rank-p update (d > 0) or downdate (d < 0) to A, or a mix
-    of both. When d is omitted, D = I and H = A + kappa @ kappa^T.
+    some special structure that makes it easy to solve A * y = c, kappa is M-by-p
+    (p << M), and D = diag(d). Thus, H is a rank-p update (d > 0) or downdate (d < 0) to
+    A, or a mix of both. When d is omitted, D = I and H = A + kappa @ kappa^T.
 
     Parameters
     ----------
@@ -216,16 +221,16 @@ def solve_rank_p_update(
     Notes
     -----
     Let H = A + kappa @ D @ kappa^T, where kappa is an M-by-p matrix and D = diag(d).
-    By the Woodbury identity, the Schur complement matrix is
-    G = D^{-1} + kappa^T @ A^{-1} @ kappa. The formula is valid whenever G is invertible.
+    By the Woodbury identity, the Woodbury matrix is:
+       G = D^{-1} + kappa^T @ A^{-1} @ kappa.
+    The formula is valid whenever G is invertible.
 
     When A is positive definite, the sign structure of d determines how we check H's
     positive definiteness via G:
      - All d > 0 (pure update): G is always PD; H is always PD. Checked via Cholesky(G).
      - All d < 0 (pure downdate): H is PD iff G is negative definite (ND), i.e. -G is
        PD. Checked via Cholesky(-G). If -G is not PD, H is indefinite.
-     - Mixed d: PD status requires full eigenvalue analysis; we check only invertibility
-       via LU, and the solve is algebraically correct whenever G is invertible.
+     - Mixed d: We assess PD status via eigenvalue analysis. We then solve Gy = z via LU.
 
     We can solve H * x = b in O((p + q) * t + 2 * M * p * (p + 2 * q)) time, where t is
     the number of flops needed to solve A*y = c, as follows:
@@ -242,8 +247,11 @@ def solve_rank_p_update(
     if b.ndim not in (1, 2):
         raise ValueError("b must be either a 1D or 2D NumPy array.")
 
+    if kappa.ndim != 2:
+        raise ValueError("kappa must be a 2D array with shape (M, p).")
+
     if b.shape[0] != kappa.shape[0]:
-        raise ValueError("Number of rows in beta must match length of kappa.")
+        raise ValueError("b.shape[0] must equal kappa.shape[0].")
 
     p = kappa.shape[1]
 
@@ -261,6 +269,9 @@ def solve_rank_p_update(
         G = np.diag(1.0 / d) + kappa.T @ xi
     else:
         G = np.eye(p) + kappa.T @ xi
+
+    # Clean up any asymmetries before factoring
+    G = 0.5 * (G + G.T)
 
     # q RHS -> x_prime is M-by-q
     x_prime = A_solve(b, **kwargs)
@@ -283,11 +294,27 @@ def solve_rank_p_update(
         y = -linalg.cho_solve((c, lower), z)
     else:
         # Mixed signs: check invertibility only via LU.
+        evals = np.linalg.eigvalsh(G)
+        tol = 1e-12 * max(1.0, np.max(np.abs(evals)))
+
+        n_pos_G = np.sum(evals > tol)
+        n_neg_G = np.sum(evals < -tol)
+        n_zero_G = len(evals) - n_pos_G - n_neg_G
+
+        n_pos_D = np.sum(d > 0)
+        n_neg_D = np.sum(d < 0)
+
+        if n_zero_G > 0:
+            raise NewtonStepError("H is singular or nearly singular")
+
+        if n_pos_G != n_pos_D or n_neg_G != n_neg_D:
+            raise NewtonStepError("H is not positive definite")
+
         try:
             lu, piv = linalg.lu_factor(G)
             y = linalg.lu_solve((lu, piv), z)
         except np.linalg.LinAlgError:
-            raise NewtonStepError("H is not positive definite") from None
+            raise NewtonStepError("Failed to solve Gy = z") from None
 
     return x_prime - xi @ y
 
@@ -844,9 +871,9 @@ def multiply_rank_one_update(
     scale = d if d is not None else 1.0
     Ay = A_multiply(y, **kwargs)
     if y.ndim == 1:
-        return Ay + scale * kappa * np.dot(kappa, y)
+        return Ay + kappa * (scale * np.dot(kappa, y))
     else:
-        return Ay + scale * np.outer(kappa, kappa.T @ y)
+        return Ay + np.outer(kappa, scale * (kappa.T @ y))
 
 
 def multiply_rank_p_update(

--- a/test/test_matrix_multiply.py
+++ b/test/test_matrix_multiply.py
@@ -697,3 +697,118 @@ def test_multiply_arrow_plus_rank_p_with_d_multiple_rhs(
     )
 
     np.testing.assert_allclose(Z, Z_expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "seed,M",
+    [
+        (1120, 100),
+        (1220, 200),
+        (1320, 50),
+        (1420, 500),
+        (1520, 13),
+    ],
+)
+def test_multiply_rank_one_downdate(seed: int, M: int) -> None:
+    """Test computing H@y for H = diag(eta) + d*kappa*kappa^T with negative d."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    kappa = np.random.randn(M)
+    # d negative: downdate. Keep |d| small enough that H stays PD.
+    d = -(float(np.random.rand()) * 0.5 / (np.dot(kappa, kappa / eta) + 1e-6))
+    H = np.diag(eta) + d * np.outer(kappa, kappa)
+    y = np.random.randn(M)
+
+    z_expected = H @ y
+    z = multiply_rank_one_update(y, kappa, A_multiply=multiply_diagonal, d=d, eta=eta)
+
+    np.testing.assert_allclose(z, z_expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "seed,M,r",
+    [
+        (1121, 100, 3),
+        (1221, 200, 10),
+        (1321, 50, 2),
+        (1421, 500, 10),
+        (1521, 13, 2),
+    ],
+)
+def test_multiply_rank_p_downdate(seed: int, M: int, r: int) -> None:
+    """Test computing H@y for H = arrow + kappa @ D @ kappa^T with negative d."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    zeta = np.random.randn(M)
+    theta = np.dot(zeta / eta, zeta) + 1.0
+    kappa = np.random.randn(M + 1, r)
+    d = -(np.random.rand(r) * 0.5)
+
+    A = np.zeros((M + 1, M + 1))
+    A[0:M, 0:M] = np.diag(eta)
+    A[M, 0:M] = zeta
+    A[0:M, M] = zeta
+    A[M, M] = theta
+
+    H = A + kappa @ np.diag(d) @ kappa.T
+    y = np.random.randn(M + 1)
+
+    z_expected = H @ y
+    z = multiply_rank_p_update(
+        y,
+        kappa,
+        A_multiply=multiply_arrow_sparsity_pattern,
+        d=d,
+        eta=eta,
+        zeta=zeta,
+        theta=theta,
+    )
+
+    np.testing.assert_allclose(z, z_expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "seed,M,r",
+    [
+        (1122, 100, 4),
+        (1222, 200, 6),
+        (1322, 50, 3),
+        (1422, 500, 8),
+        (1522, 13, 3),
+    ],
+)
+def test_multiply_rank_p_mixed_d(seed: int, M: int, r: int) -> None:
+    """Test computing H@y for H = arrow + kappa @ D @ kappa^T with mixed-sign d."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    zeta = np.random.randn(M)
+    theta = np.dot(zeta / eta, zeta) + 1.0
+    kappa = np.random.randn(M + 1, r)
+    # Half positive, half negative
+    d = np.where(
+        np.arange(r) % 2 == 0,
+        np.random.rand(r) + 0.5,
+        -(np.random.rand(r) * 0.3),
+    )
+
+    A = np.zeros((M + 1, M + 1))
+    A[0:M, 0:M] = np.diag(eta)
+    A[M, 0:M] = zeta
+    A[0:M, M] = zeta
+    A[M, M] = theta
+
+    H = A + kappa @ np.diag(d) @ kappa.T
+    y = np.random.randn(M + 1)
+
+    z_expected = H @ y
+    z = multiply_rank_p_update(
+        y,
+        kappa,
+        A_multiply=multiply_arrow_sparsity_pattern,
+        d=d,
+        eta=eta,
+        zeta=zeta,
+        theta=theta,
+    )
+
+    np.testing.assert_allclose(z, z_expected, rtol=1e-12, atol=1e-12)

--- a/test/test_matrix_multiply.py
+++ b/test/test_matrix_multiply.py
@@ -559,3 +559,141 @@ def test_multiply_banded_lower(seed: int, M: int, bw: int) -> None:
     z = multiply_banded(y, ab_lower, lower=True)
 
     np.testing.assert_allclose(z, z_expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "seed,M",
+    [
+        (1116, 100),
+        (1216, 200),
+        (1316, 50),
+        (1416, 500),
+        (1516, 13),
+    ],
+)
+def test_multiply_diagonal_plus_rank_one_with_d(seed: int, M: int) -> None:
+    """Test computing H@y for H = diag(eta) + d*kappa*kappa^T with scalar d."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    kappa = np.random.randn(M)
+    d = float(np.random.rand() + 0.5)
+    H = np.diag(eta) + d * np.outer(kappa, kappa)
+    y = np.random.randn(M)
+
+    z_expected = H @ y
+    z = multiply_rank_one_update(y, kappa, A_multiply=multiply_diagonal, d=d, eta=eta)
+
+    np.testing.assert_allclose(z, z_expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "seed,M,p",
+    [
+        (1117, 100, 20),
+        (1217, 200, 30),
+        (1317, 50, 5),
+        (1417, 500, 100),
+        (1517, 13, 3),
+    ],
+)
+def test_multiply_diagonal_plus_rank_one_with_d_multiple_rhs(
+    seed: int, M: int, p: int
+) -> None:
+    """Test computing H@Y for H = diag(eta) + d*kappa*kappa^T, matrix Y."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    kappa = np.random.randn(M)
+    d = float(np.random.rand() + 0.5)
+    H = np.diag(eta) + d * np.outer(kappa, kappa)
+    Y = np.random.randn(M, p)
+
+    Z_expected = H @ Y
+    Z = multiply_rank_one_update(Y, kappa, A_multiply=multiply_diagonal, d=d, eta=eta)
+
+    np.testing.assert_allclose(Z, Z_expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "seed,M,r",
+    [
+        (1118, 100, 3),
+        (1218, 200, 10),
+        (1318, 50, 2),
+        (1418, 500, 10),
+        (1518, 13, 2),
+    ],
+)
+def test_multiply_arrow_plus_rank_p_with_d(seed: int, M: int, r: int) -> None:
+    """Test computing H@y for H = arrow + kappa @ D @ kappa^T with diagonal D."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    zeta = np.random.randn(M)
+    theta = np.dot(zeta / eta, zeta) + 1.0
+    kappa = np.random.randn(M + 1, r)
+    d = np.random.rand(r) + 0.5
+
+    A = np.zeros((M + 1, M + 1))
+    A[0:M, 0:M] = np.diag(eta)
+    A[M, 0:M] = zeta
+    A[0:M, M] = zeta
+    A[M, M] = theta
+
+    H = A + kappa @ np.diag(d) @ kappa.T
+    y = np.random.randn(M + 1)
+
+    z_expected = H @ y
+    z = multiply_rank_p_update(
+        y,
+        kappa,
+        A_multiply=multiply_arrow_sparsity_pattern,
+        d=d,
+        eta=eta,
+        zeta=zeta,
+        theta=theta,
+    )
+
+    np.testing.assert_allclose(z, z_expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "seed,M,r,p",
+    [
+        (1119, 100, 3, 20),
+        (1219, 200, 10, 30),
+        (1319, 50, 2, 5),
+        (1419, 500, 10, 50),
+        (1519, 13, 2, 4),
+    ],
+)
+def test_multiply_arrow_plus_rank_p_with_d_multiple_rhs(
+    seed: int, M: int, r: int, p: int
+) -> None:
+    """Test computing H@Y for H = arrow + kappa @ D @ kappa^T, matrix Y."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    zeta = np.random.randn(M)
+    theta = np.dot(zeta / eta, zeta) + 1.0
+    kappa = np.random.randn(M + 1, r)
+    d = np.random.rand(r) + 0.5
+
+    A = np.zeros((M + 1, M + 1))
+    A[0:M, 0:M] = np.diag(eta)
+    A[M, 0:M] = zeta
+    A[0:M, M] = zeta
+    A[M, M] = theta
+
+    H = A + kappa @ np.diag(d) @ kappa.T
+    Y = np.random.randn(M + 1, p)
+
+    Z_expected = H @ Y
+    Z = multiply_rank_p_update(
+        Y,
+        kappa,
+        A_multiply=multiply_arrow_sparsity_pattern,
+        d=d,
+        eta=eta,
+        zeta=zeta,
+        theta=theta,
+    )
+
+    np.testing.assert_allclose(Z, Z_expected, rtol=1e-12, atol=1e-12)

--- a/test/test_multi_objective.py
+++ b/test/test_multi_objective.py
@@ -1,0 +1,334 @@
+"""Tests for MultiObjectiveOptimizer and FrontierResults."""
+
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from cvxium import InteriorPointMethodResult
+from cvxium.multi_objective import (
+    FrontierPoint,
+    FrontierResults,
+    MultiObjectiveOptimizer,
+)
+
+# ---------------------------------------------------------------------------
+# Analytical test solver: minimize ||x||^2 s.t. ||x - d||^2 <= phi
+#
+# Two objectives:
+#   f0(x) = ||x||^2          (primary)
+#   f1(x) = ||x - d||^2     (auxiliary, bounded by phi)
+#
+# Analytical solution for given phi:
+#   If phi >= ||d||^2: x* = 0         (unconstrained min is feasible)
+#   Else:              x* = d * (1 - sqrt(phi) / ||d||)
+#
+# The frontier is the curve f0 = (||d|| - sqrt(f1))^2 for f1 in [0, ||d||^2].
+# ---------------------------------------------------------------------------
+
+
+def _make_ipm_result(
+    x: npt.NDArray[np.float64], obj: float
+) -> InteriorPointMethodResult:
+    """Construct a minimal InteriorPointMethodResult for testing."""
+    return InteriorPointMethodResult(
+        solution=x.copy(),
+        objective_value=obj,
+        dual_value=obj,
+        equality_multipliers=np.array([]),
+        inequality_multipliers=np.array([0.0]),
+        suboptimality=0.0,
+        duality_gaps=[0.0],
+        nits=1,
+        inner_nits=[1],
+        inner_suboptimalities=[[0.0]],
+        status=0,
+        message="analytical",
+    )
+
+
+class BallConstrainedNorm(MultiObjectiveOptimizer):
+    r"""Analytical two-objective solver.
+
+    Objectives:
+        f0(x) = ||x||^2
+        f1(x) = ||x - d||^2
+
+    solve_with_bounds([phi]) solves:
+        minimize f0(x) s.t. f1(x) <= phi
+    """
+
+    def __init__(self, d: npt.NDArray[np.float64], primary_objective: int = 0) -> None:
+        super().__init__(primary_objective=primary_objective)
+        self.d = d
+        self._d_norm = float(np.linalg.norm(d))
+
+    def solve_with_bounds(
+        self, bounds: npt.NDArray[np.float64]
+    ) -> InteriorPointMethodResult:
+        phi = float(bounds[0])
+        d_norm_sq = self._d_norm**2
+        if phi >= d_norm_sq:
+            x = np.zeros_like(self.d)
+        else:
+            x = self.d * (1.0 - np.sqrt(phi) / self._d_norm)
+        return _make_ipm_result(x, float(np.dot(x, x)))
+
+    def minimize_objective(self, objective_index: int) -> InteriorPointMethodResult:
+        if objective_index == 0:
+            x = np.zeros_like(self.d)
+        else:
+            x = self.d.copy()
+        return _make_ipm_result(x, float(np.dot(x - self.d * objective_index, x - self.d * objective_index)))
+
+    def evaluate_objectives(
+        self, x: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        f0 = float(np.dot(x, x))
+        f1 = float(np.dot(x - self.d, x - self.d))
+        return np.array([f0, f1])
+
+
+class SeparableBallConstraints(MultiObjectiveOptimizer):
+    r"""Analytical three-objective solver (separable by dimension).
+
+    Decision variable x in R^2.
+    Objectives:
+        f0(x) = x[0]^2 + x[1]^2
+        f1(x) = (x[0] - 1)^2
+        f2(x) = (x[1] - 1)^2
+
+    solve_with_bounds([phi1, phi2]) has separable solution:
+        x[k]* = 0 if phi_{k+1} >= 1 else 1 - sqrt(phi_{k+1})
+    """
+
+    def __init__(self, primary_objective: int = 0) -> None:
+        super().__init__(primary_objective=primary_objective)
+
+    def _solve_1d(self, phi: float) -> float:
+        """Minimize x^2 s.t. (x-1)^2 <= phi."""
+        if phi >= 1.0:
+            return 0.0
+        return 1.0 - np.sqrt(phi)
+
+    def solve_with_bounds(
+        self, bounds: npt.NDArray[np.float64]
+    ) -> InteriorPointMethodResult:
+        x0 = self._solve_1d(float(bounds[0]))
+        x1 = self._solve_1d(float(bounds[1]))
+        x = np.array([x0, x1])
+        return _make_ipm_result(x, float(np.dot(x, x)))
+
+    def minimize_objective(self, objective_index: int) -> InteriorPointMethodResult:
+        if objective_index == 0:
+            x = np.zeros(2)
+        elif objective_index == 1:
+            x = np.array([1.0, 0.0])
+        else:
+            x = np.array([0.0, 1.0])
+        return _make_ipm_result(x, float(np.dot(x, x)))
+
+    def evaluate_objectives(
+        self, x: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        return np.array([
+            float(x[0] ** 2 + x[1] ** 2),
+            float((x[0] - 1.0) ** 2),
+            float((x[1] - 1.0) ** 2),
+        ])
+
+
+# ---------------------------------------------------------------------------
+# Tests: two objectives
+# ---------------------------------------------------------------------------
+
+
+class TestTwoObjectiveFrontier:
+    """Tests for a two-objective optimizer."""
+
+    @pytest.fixture
+    def solver(self) -> BallConstrainedNorm:
+        rng = np.random.default_rng(42)
+        d = rng.standard_normal(5)
+        return BallConstrainedNorm(d=d)
+
+    def test_trace_returns_points(self, solver: BallConstrainedNorm) -> None:
+        """trace() returns a non-empty FrontierResults."""
+        results = solver.trace(num_points=10)
+        assert isinstance(results, FrontierResults)
+        assert len(results.points) > 0
+
+    def test_corners_computed(self, solver: BallConstrainedNorm) -> None:
+        """Two corner points are computed, one per objective."""
+        results = solver.trace(num_points=5)
+        assert len(results.corners) == 2
+
+    def test_primary_corner_minimizes_f0(self, solver: BallConstrainedNorm) -> None:
+        """Corner 0 (primary) achieves f0 near zero."""
+        results = solver.trace(num_points=5)
+        primary_corner = results.corners[0]
+        assert primary_corner.objectives[0] == pytest.approx(0.0, abs=1e-10)
+
+    def test_auxiliary_corner_minimizes_f1(self, solver: BallConstrainedNorm) -> None:
+        """Corner 1 (auxiliary) achieves f1 near zero."""
+        results = solver.trace(num_points=5)
+        aux_corner = results.corners[1]
+        assert aux_corner.objectives[1] == pytest.approx(0.0, abs=1e-10)
+
+    def test_frontier_monotone(self, solver: BallConstrainedNorm) -> None:
+        """As phi (auxiliary bound) increases, f0 is non-increasing."""
+        results = solver.trace(num_points=20)
+        # Sort points by bounds (phi value).
+        interior_points = [p for p in results.points if not np.any(np.isinf(p.bounds))]
+        interior_points.sort(key=lambda p: float(p.bounds[0]))
+        f0_values = [p.objectives[0] for p in interior_points]
+        # f0 should be non-increasing as the constraint relaxes.
+        for i in range(len(f0_values) - 1):
+            assert f0_values[i] >= f0_values[i + 1] - 1e-10
+
+    def test_frontier_matches_analytical(self, solver: BallConstrainedNorm) -> None:
+        """Frontier points match the analytical formula f0 = (||d|| - sqrt(f1))^2."""
+        d_norm = solver._d_norm
+        results = solver.trace(num_points=20)
+        for p in results.points:
+            f0, f1 = float(p.objectives[0]), float(p.objectives[1])
+            expected_f0 = max(0.0, (d_norm - np.sqrt(max(f1, 0.0))) ** 2)
+            assert f0 == pytest.approx(expected_f0, abs=1e-8)
+
+    def test_knee_is_a_frontier_point(self, solver: BallConstrainedNorm) -> None:
+        """knee() returns one of the points in results.points (by identity)."""
+        results = solver.trace(num_points=10)
+        knee = results.knee()
+        assert any(knee is p for p in results.points)
+
+    def test_knee_not_at_extreme(self, solver: BallConstrainedNorm) -> None:
+        """Knee is not the same as either corner (it should be in the interior)."""
+        results = solver.trace(num_points=20)
+        knee = results.knee()
+        # The knee should not have f0=0 (primary corner) nor f1=0 (aux corner).
+        assert knee.objectives[0] > 1e-6
+        assert knee.objectives[1] > 1e-6
+
+    def test_primary_objective_stored(self, solver: BallConstrainedNorm) -> None:
+        """FrontierResults records primary_objective correctly."""
+        results = solver.trace(num_points=5)
+        assert results.primary_objective == 0
+
+    @pytest.mark.parametrize("primary", [0, 1])
+    def test_primary_objective_constructor(self, primary: int) -> None:
+        """primary_objective constructor parameter is respected."""
+        d = np.array([1.0, 2.0, 3.0])
+        solver = BallConstrainedNorm(d=d, primary_objective=primary)
+        assert solver.primary_objective == primary
+        results = solver.trace(num_points=5)
+        assert results.primary_objective == primary
+
+
+# ---------------------------------------------------------------------------
+# Tests: FrontierResults.knee geometry
+# ---------------------------------------------------------------------------
+
+
+class TestKneeGeometry:
+    """Unit tests for the knee calculation."""
+
+    def _make_point(
+        self, objectives: list[float], solution: list[float] | None = None
+    ) -> FrontierPoint:
+        if solution is None:
+            solution = [0.0] * len(objectives)
+        ipm = _make_ipm_result(np.array(solution), 0.0)
+        return FrontierPoint(
+            objectives=np.array(objectives),
+            solution=np.array(solution),
+            bounds=np.array([np.inf]),
+            ipm_result=ipm,
+        )
+
+    def test_knee_2d_midpoint(self) -> None:
+        """For a symmetric curve, knee is near the midpoint of the chord."""
+        # Corners at (0, 1) and (1, 0); midpoint of chord at (0.5, 0.5).
+        corners = [
+            self._make_point([0.0, 1.0]),
+            self._make_point([1.0, 0.0]),
+        ]
+        # Frontier: f0 + f1 = 1 (linear — all points equidistant from chord).
+        # Use a curved frontier: f0 = (1 - sqrt(f1))^2 with f1 in [0,1].
+        f1_vals = np.linspace(0.0, 1.0, 51)
+        points = list(corners) + [
+            self._make_point([(1.0 - np.sqrt(f1)) ** 2, f1]) for f1 in f1_vals[1:-1]
+        ]
+        results = FrontierResults(points=points, corners=corners, primary_objective=0)
+        knee = results.knee()
+        # The knee should be interior, not at the corners.
+        assert knee.objectives[0] > 0.01
+        assert knee.objectives[1] > 0.01
+
+    def test_knee_raises_on_empty_points(self) -> None:
+        """knee() raises ValueError when points list is empty."""
+        corners = [self._make_point([0.0, 1.0]), self._make_point([1.0, 0.0])]
+        results = FrontierResults(points=[], corners=corners, primary_objective=0)
+        with pytest.raises(ValueError, match="No frontier points"):
+            results.knee()
+
+    def test_knee_raises_with_single_corner(self) -> None:
+        """knee() raises ValueError when fewer than 2 corners are available."""
+        corner = self._make_point([0.0, 1.0])
+        point = self._make_point([0.5, 0.5])
+        results = FrontierResults(
+            points=[corner, point], corners=[corner], primary_objective=0
+        )
+        with pytest.raises(ValueError, match="at least 2 corner points"):
+            results.knee()
+
+
+# ---------------------------------------------------------------------------
+# Tests: three objectives
+# ---------------------------------------------------------------------------
+
+
+class TestThreeObjectiveFrontier:
+    """Tests for the three-objective separable solver."""
+
+    @pytest.fixture
+    def solver(self) -> SeparableBallConstraints:
+        return SeparableBallConstraints(primary_objective=0)
+
+    def test_trace_returns_points(self, solver: SeparableBallConstraints) -> None:
+        """trace() returns a non-empty FrontierResults for N=3."""
+        results = solver.trace(num_points=5)
+        assert len(results.points) > 0
+
+    def test_three_corners_computed(self, solver: SeparableBallConstraints) -> None:
+        """Three corner points are computed for three objectives."""
+        results = solver.trace(num_points=5)
+        assert len(results.corners) == 3
+
+    def test_primary_corner_f0_zero(self, solver: SeparableBallConstraints) -> None:
+        """Primary corner minimizes f0 to zero."""
+        results = solver.trace(num_points=5)
+        assert results.corners[0].objectives[0] == pytest.approx(0.0, abs=1e-10)
+
+    def test_aux1_corner_f1_zero(self, solver: SeparableBallConstraints) -> None:
+        """First auxiliary corner minimizes f1 to zero."""
+        results = solver.trace(num_points=5)
+        assert results.corners[1].objectives[1] == pytest.approx(0.0, abs=1e-10)
+
+    def test_aux2_corner_f2_zero(self, solver: SeparableBallConstraints) -> None:
+        """Second auxiliary corner minimizes f2 to zero."""
+        results = solver.trace(num_points=5)
+        assert results.corners[2].objectives[2] == pytest.approx(0.0, abs=1e-10)
+
+    def test_grid_size(self, solver: SeparableBallConstraints) -> None:
+        """For N=3 and num_points=k, the grid contributes at most k^2 points."""
+        num_points = 4
+        results = solver.trace(num_points=num_points)
+        # corners (3) + up to num_points^2 grid points
+        assert len(results.points) <= 3 + num_points**2
+
+    def test_knee_available(self, solver: SeparableBallConstraints) -> None:
+        """knee() returns a FrontierPoint for N=3."""
+        results = solver.trace(num_points=5)
+        knee = results.knee()
+        assert isinstance(knee, FrontierPoint)
+        assert any(knee is p for p in results.points)

--- a/test/test_multi_objective.py
+++ b/test/test_multi_objective.py
@@ -5,6 +5,7 @@ import numpy.typing as npt
 import pytest
 
 from cvxium import InteriorPointMethodResult
+from cvxium.exceptions import OptimizationError
 from cvxium.multi_objective import (
     FrontierPoint,
     FrontierResults,
@@ -12,17 +13,23 @@ from cvxium.multi_objective import (
 )
 
 # ---------------------------------------------------------------------------
-# Analytical test solver: minimize ||x||^2 s.t. ||x - d||^2 <= phi
+# Analytical test solver: minimize ||x||^2 s.t. ||x - d||^2 <= phi  (primary=0)
+#                    or: minimize ||x-d||^2 s.t. ||x||^2 <= phi      (primary=1)
 #
 # Two objectives:
-#   f0(x) = ||x||^2          (primary)
-#   f1(x) = ||x - d||^2     (auxiliary, bounded by phi)
+#   f0(x) = ||x||^2
+#   f1(x) = ||x - d||^2
 #
-# Analytical solution for given phi:
-#   If phi >= ||d||^2: x* = 0         (unconstrained min is feasible)
-#   Else:              x* = d * (1 - sqrt(phi) / ||d||)
+# Analytical solutions:
+#   primary=0, bound phi on f1:
+#     phi >= ||d||^2 → x* = 0,            f0* = 0,              f1* = ||d||^2
+#     phi <  ||d||^2 → x* = d(1-√φ/‖d‖), f0* = (‖d‖-√φ)^2,   f1* = φ
 #
-# The frontier is the curve f0 = (||d|| - sqrt(f1))^2 for f1 in [0, ||d||^2].
+#   primary=1, bound phi on f0:
+#     phi >= ||d||^2 → x* = d,            f0* = ||d||^2,        f1* = 0
+#     phi <  ||d||^2 → x* = d·√φ/‖d‖,    f0* = φ,              f1* = (‖d‖-√φ)^2
+#
+# In both cases the Pareto frontier is the curve f0=(‖d‖-√f1)^2, f1 in [0,‖d‖^2].
 # ---------------------------------------------------------------------------
 
 
@@ -47,14 +54,14 @@ def _make_ipm_result(
 
 
 class BallConstrainedNorm(MultiObjectiveOptimizer):
-    r"""Analytical two-objective solver.
+    r"""Analytical two-objective solver respecting primary_objective.
 
     Objectives:
         f0(x) = ||x||^2
         f1(x) = ||x - d||^2
 
-    solve_with_bounds([phi]) solves:
-        minimize f0(x) s.t. f1(x) <= phi
+    When primary_objective=0: solve_with_bounds([phi]) minimises f0 s.t. f1 <= phi.
+    When primary_objective=1: solve_with_bounds([phi]) minimises f1 s.t. f0 <= phi.
     """
 
     def __init__(self, d: npt.NDArray[np.float64], primary_objective: int = 0) -> None:
@@ -67,27 +74,31 @@ class BallConstrainedNorm(MultiObjectiveOptimizer):
     ) -> InteriorPointMethodResult:
         phi = float(bounds[0])
         d_norm_sq = self._d_norm**2
-        if phi >= d_norm_sq:
-            x = np.zeros_like(self.d)
+        if self.primary_objective == 0:
+            # minimize ||x||^2 s.t. ||x-d||^2 <= phi
+            x = (
+                np.zeros_like(self.d)
+                if phi >= d_norm_sq
+                else self.d * (1.0 - np.sqrt(phi) / self._d_norm)
+            )
         else:
-            x = self.d * (1.0 - np.sqrt(phi) / self._d_norm)
+            # minimize ||x-d||^2 s.t. ||x||^2 <= phi
+            x = (
+                self.d.copy()
+                if phi >= d_norm_sq
+                else self.d * (np.sqrt(phi) / self._d_norm)
+            )
         return _make_ipm_result(x, float(np.dot(x, x)))
 
     def minimize_objective(self, objective_index: int) -> InteriorPointMethodResult:
-        if objective_index == 0:
-            x = np.zeros_like(self.d)
-        else:
-            x = self.d.copy()
-        return _make_ipm_result(
-            x, float(np.dot(x - self.d * objective_index, x - self.d * objective_index))
-        )
+        # minimize f0 → x=0; minimize f1 → x=d
+        x = np.zeros_like(self.d) if objective_index == 0 else self.d.copy()
+        return _make_ipm_result(x, float(np.dot(x, x)))
 
     def evaluate_objectives(
         self, x: npt.NDArray[np.float64]
     ) -> npt.NDArray[np.float64]:
-        f0 = float(np.dot(x, x))
-        f1 = float(np.dot(x - self.d, x - self.d))
-        return np.array([f0, f1])
+        return np.array([float(np.dot(x, x)), float(np.dot(x - self.d, x - self.d))])
 
 
 class SeparableBallConstraints(MultiObjectiveOptimizer):
@@ -99,8 +110,8 @@ class SeparableBallConstraints(MultiObjectiveOptimizer):
         f1(x) = (x[0] - 1)^2
         f2(x) = (x[1] - 1)^2
 
-    solve_with_bounds([phi1, phi2]) has separable solution:
-        x[k]* = 0 if phi_{k+1} >= 1 else 1 - sqrt(phi_{k+1})
+    primary_objective=0: solve_with_bounds([phi1, phi2]) imposes f1<=phi1, f2<=phi2.
+    Separable solution: x[k]* = 0 if phi_{k+1} >= 1 else 1 - sqrt(phi_{k+1}).
     """
 
     def __init__(self, primary_objective: int = 0) -> None:
@@ -142,7 +153,22 @@ class SeparableBallConstraints(MultiObjectiveOptimizer):
 
 
 # ---------------------------------------------------------------------------
-# Tests: two objectives
+# Helper: a solver whose auxiliary corner solves always fail (to test knee()
+# behaviour with incomplete corners).
+# ---------------------------------------------------------------------------
+
+
+class PartialCornerSolver(BallConstrainedNorm):
+    """Like BallConstrainedNorm but minimize_objective fails for objective 1."""
+
+    def minimize_objective(self, objective_index: int) -> InteriorPointMethodResult:
+        if objective_index == 1:
+            raise OptimizationError("synthetic failure", 1.0, np.zeros(1))
+        return super().minimize_objective(objective_index)
+
+
+# ---------------------------------------------------------------------------
+# Tests: two objectives, primary_objective=0
 # ---------------------------------------------------------------------------
 
 
@@ -169,23 +195,19 @@ class TestTwoObjectiveFrontier:
     def test_primary_corner_minimizes_f0(self, solver: BallConstrainedNorm) -> None:
         """Corner 0 (primary) achieves f0 near zero."""
         results = solver.trace(num_points=5)
-        primary_corner = results.corners[0]
-        assert primary_corner.objectives[0] == pytest.approx(0.0, abs=1e-10)
+        assert results.corners[0].objectives[0] == pytest.approx(0.0, abs=1e-10)
 
     def test_auxiliary_corner_minimizes_f1(self, solver: BallConstrainedNorm) -> None:
         """Corner 1 (auxiliary) achieves f1 near zero."""
         results = solver.trace(num_points=5)
-        aux_corner = results.corners[1]
-        assert aux_corner.objectives[1] == pytest.approx(0.0, abs=1e-10)
+        assert results.corners[1].objectives[1] == pytest.approx(0.0, abs=1e-10)
 
     def test_frontier_monotone(self, solver: BallConstrainedNorm) -> None:
         """As phi (auxiliary bound) increases, f0 is non-increasing."""
         results = solver.trace(num_points=20)
-        # Sort points by bounds (phi value).
-        interior_points = [p for p in results.points if not np.any(np.isinf(p.bounds))]
-        interior_points.sort(key=lambda p: float(p.bounds[0]))
-        f0_values = [p.objectives[0] for p in interior_points]
-        # f0 should be non-increasing as the constraint relaxes.
+        interior = [p for p in results.points if not np.any(np.isinf(p.bounds))]
+        interior.sort(key=lambda p: float(p.bounds[0]))
+        f0_values = [p.objectives[0] for p in interior]
         for i in range(len(f0_values) - 1):
             assert f0_values[i] >= f0_values[i + 1] - 1e-10
 
@@ -208,7 +230,6 @@ class TestTwoObjectiveFrontier:
         """Knee is not the same as either corner (it should be in the interior)."""
         results = solver.trace(num_points=20)
         knee = results.knee()
-        # The knee should not have f0=0 (primary corner) nor f1=0 (aux corner).
         assert knee.objectives[0] > 1e-6
         assert knee.objectives[1] > 1e-6
 
@@ -217,14 +238,82 @@ class TestTwoObjectiveFrontier:
         results = solver.trace(num_points=5)
         assert results.primary_objective == 0
 
-    @pytest.mark.parametrize("primary", [0, 1])
-    def test_primary_objective_constructor(self, primary: int) -> None:
-        """primary_objective constructor parameter is respected."""
-        d = np.array([1.0, 2.0, 3.0])
-        solver = BallConstrainedNorm(d=d, primary_objective=primary)
-        assert solver.primary_objective == primary
+    def test_diagnostics(self, solver: BallConstrainedNorm) -> None:
+        """n_attempted and n_skipped are tracked correctly."""
+        num_points = 7
+        results = solver.trace(num_points=num_points)
+        # For N=2 there is 1 auxiliary, so grid has num_points points.
+        assert results.n_attempted == num_points
+        # This solver never raises, so nothing is skipped.
+        assert results.n_skipped == 0
+
+    def test_num_points_validation(self, solver: BallConstrainedNorm) -> None:
+        """trace() raises ValueError for num_points < 1."""
+        with pytest.raises(ValueError, match="num_points must be >= 1"):
+            solver.trace(num_points=0)
+        with pytest.raises(ValueError, match="num_points must be >= 1"):
+            solver.trace(num_points=-5)
+
+    def test_deduplication(self, solver: BallConstrainedNorm) -> None:
+        """No two points in results.points share an objective vector."""
+        results = solver.trace(num_points=20)
+        for i, p in enumerate(results.points):
+            for q in results.points[:i]:
+                assert not np.allclose(p.objectives, q.objectives, atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Tests: two objectives, primary_objective=1
+# ---------------------------------------------------------------------------
+
+
+class TestTwoObjectiveFrontierAlternatePrimary:
+    """Correctness tests when the non-default objective is primary."""
+
+    @pytest.fixture
+    def solver(self) -> BallConstrainedNorm:
+        rng = np.random.default_rng(99)
+        d = rng.standard_normal(4)
+        return BallConstrainedNorm(d=d, primary_objective=1)
+
+    def test_primary_corner_minimizes_f1(self, solver: BallConstrainedNorm) -> None:
+        """With primary=1, corner 0 minimizes f1 (||x-d||^2) to zero."""
         results = solver.trace(num_points=5)
-        assert results.primary_objective == primary
+        assert results.corners[0].objectives[1] == pytest.approx(0.0, abs=1e-10)
+
+    def test_auxiliary_corner_minimizes_f0(self, solver: BallConstrainedNorm) -> None:
+        """With primary=1, corner 1 (the auxiliary corner) minimizes f0 to zero."""
+        results = solver.trace(num_points=5)
+        assert results.corners[1].objectives[0] == pytest.approx(0.0, abs=1e-10)
+
+    def test_frontier_monotone(self, solver: BallConstrainedNorm) -> None:
+        """As f0 bound increases, f1 (primary) is non-increasing."""
+        results = solver.trace(num_points=20)
+        interior = [p for p in results.points if not np.any(np.isinf(p.bounds))]
+        interior.sort(key=lambda p: float(p.bounds[0]))
+        f1_values = [float(p.objectives[1]) for p in interior]
+        for i in range(len(f1_values) - 1):
+            assert f1_values[i] >= f1_values[i + 1] - 1e-10
+
+    def test_frontier_matches_analytical(self, solver: BallConstrainedNorm) -> None:
+        """With primary=1, frontier still satisfies f1 = (||d|| - sqrt(f0))^2."""
+        d_norm = solver._d_norm
+        results = solver.trace(num_points=20)
+        for p in results.points:
+            f0, f1 = float(p.objectives[0]), float(p.objectives[1])
+            expected_f1 = max(0.0, (d_norm - np.sqrt(max(f0, 0.0))) ** 2)
+            assert f1 == pytest.approx(expected_f1, abs=1e-8)
+
+    def test_knee_available(self, solver: BallConstrainedNorm) -> None:
+        """knee() works for primary_objective=1."""
+        results = solver.trace(num_points=10)
+        knee = results.knee()
+        assert any(knee is p for p in results.points)
+
+    def test_primary_objective_in_results(self, solver: BallConstrainedNorm) -> None:
+        """FrontierResults records primary_objective=1."""
+        results = solver.trace(num_points=5)
+        assert results.primary_objective == 1
 
 
 # ---------------------------------------------------------------------------
@@ -249,28 +338,32 @@ class TestKneeGeometry:
         )
 
     def test_knee_2d_midpoint(self) -> None:
-        """For a symmetric curve, knee is near the midpoint of the chord."""
-        # Corners at (0, 1) and (1, 0); midpoint of chord at (0.5, 0.5).
+        """For a curved 2-D frontier, knee is interior (not at the corners)."""
         corners = [
             self._make_point([0.0, 1.0]),
             self._make_point([1.0, 0.0]),
         ]
-        # Frontier: f0 + f1 = 1 (linear — all points equidistant from chord).
-        # Use a curved frontier: f0 = (1 - sqrt(f1))^2 with f1 in [0,1].
         f1_vals = np.linspace(0.0, 1.0, 51)
         points = list(corners) + [
             self._make_point([(1.0 - np.sqrt(f1)) ** 2, f1]) for f1 in f1_vals[1:-1]
         ]
-        results = FrontierResults(points=points, corners=corners, primary_objective=0)
+        results = FrontierResults(
+            points=points,
+            corners=corners,
+            primary_objective=0,
+            n_attempted=len(points),
+            n_skipped=0,
+        )
         knee = results.knee()
-        # The knee should be interior, not at the corners.
         assert knee.objectives[0] > 0.01
         assert knee.objectives[1] > 0.01
 
     def test_knee_raises_on_empty_points(self) -> None:
         """knee() raises ValueError when points list is empty."""
         corners = [self._make_point([0.0, 1.0]), self._make_point([1.0, 0.0])]
-        results = FrontierResults(points=[], corners=corners, primary_objective=0)
+        results = FrontierResults(
+            points=[], corners=corners, primary_objective=0, n_attempted=0, n_skipped=0
+        )
         with pytest.raises(ValueError, match="No frontier points"):
             results.knee()
 
@@ -279,9 +372,31 @@ class TestKneeGeometry:
         corner = self._make_point([0.0, 1.0])
         point = self._make_point([0.5, 0.5])
         results = FrontierResults(
-            points=[corner, point], corners=[corner], primary_objective=0
+            points=[corner, point],
+            corners=[corner],
+            primary_objective=0,
+            n_attempted=1,
+            n_skipped=0,
         )
         with pytest.raises(ValueError, match="at least 2 corner points"):
+            results.knee()
+
+    def test_knee_raises_with_incomplete_corners_3d(self) -> None:
+        """knee() raises when n_corners < n_objectives (partial corner failure)."""
+        # 3-D objectives but only 2 corners (one auxiliary solve failed).
+        corners = [
+            self._make_point([0.0, 1.0, 1.0]),
+            self._make_point([1.0, 0.0, 1.0]),
+        ]
+        points = [*corners, self._make_point([0.5, 0.5, 0.5])]
+        results = FrontierResults(
+            points=points,
+            corners=corners,
+            primary_objective=0,
+            n_attempted=1,
+            n_skipped=0,
+        )
+        with pytest.raises(ValueError, match="exactly one corner per objective"):
             results.knee()
 
 
@@ -326,8 +441,7 @@ class TestThreeObjectiveFrontier:
         """For N=3 and num_points=k, the grid contributes at most k^2 points."""
         num_points = 4
         results = solver.trace(num_points=num_points)
-        # corners (3) + up to num_points^2 grid points
-        assert len(results.points) <= 3 + num_points**2
+        assert results.n_attempted == num_points**2
 
     def test_knee_available(self, solver: SeparableBallConstraints) -> None:
         """knee() returns a FrontierPoint for N=3."""

--- a/test/test_multi_objective.py
+++ b/test/test_multi_objective.py
@@ -1,6 +1,5 @@
 """Tests for MultiObjectiveOptimizer and FrontierResults."""
 
-
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -79,7 +78,9 @@ class BallConstrainedNorm(MultiObjectiveOptimizer):
             x = np.zeros_like(self.d)
         else:
             x = self.d.copy()
-        return _make_ipm_result(x, float(np.dot(x - self.d * objective_index, x - self.d * objective_index)))
+        return _make_ipm_result(
+            x, float(np.dot(x - self.d * objective_index, x - self.d * objective_index))
+        )
 
     def evaluate_objectives(
         self, x: npt.NDArray[np.float64]
@@ -131,11 +132,13 @@ class SeparableBallConstraints(MultiObjectiveOptimizer):
     def evaluate_objectives(
         self, x: npt.NDArray[np.float64]
     ) -> npt.NDArray[np.float64]:
-        return np.array([
-            float(x[0] ** 2 + x[1] ** 2),
-            float((x[0] - 1.0) ** 2),
-            float((x[1] - 1.0) ** 2),
-        ])
+        return np.array(
+            [
+                float(x[0] ** 2 + x[1] ** 2),
+                float((x[0] - 1.0) ** 2),
+                float((x[1] - 1.0) ** 2),
+            ]
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_numerical_helpers.py
+++ b/test/test_numerical_helpers.py
@@ -1048,3 +1048,141 @@ def test_solve_block_diagonal_multiple_rhs(
 
     # Verify H * x = B
     np.testing.assert_allclose(H @ x, b, rtol=1e-8, atol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "seed,M",
+    [
+        (123, 100),
+        (223, 200),
+        (323, 50),
+        (423, 500),
+        (523, 13),
+    ],
+)
+def test_solve_diagonal_plus_rank_one_with_d(seed: int, M: int) -> None:
+    """Test solving H*x = b for H = diag(eta) + d*kappa*kappa^T with scalar d."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    kappa = np.random.randn(M)
+    d = float(np.random.rand() + 0.5)
+    H = np.diag(eta) + d * np.outer(kappa, kappa)
+    b = np.random.randn(M)
+
+    x_expected = np.linalg.solve(H, b)
+    x = solve_rank_one_update(b, kappa, A_solve=solve_diagonal, d=d, eta=eta)
+
+    np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)
+
+    # Verify H*x = b
+    np.testing.assert_allclose(H @ x, b, rtol=1e-8, atol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "seed,M,p",
+    [
+        (124, 100, 20),
+        (224, 200, 30),
+        (324, 50, 5),
+        (424, 500, 100),
+        (524, 13, 3),
+    ],
+)
+def test_solve_diagonal_plus_rank_one_with_d_multiple_rhs(
+    seed: int, M: int, p: int
+) -> None:
+    """Test solving H*x = b for H = diag(eta) + d*kappa*kappa^T, multiple RHS."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    kappa = np.random.randn(M)
+    d = float(np.random.rand() + 0.5)
+    H = np.diag(eta) + d * np.outer(kappa, kappa)
+    b = np.random.randn(M, p)
+
+    x_expected = np.linalg.solve(H, b)
+    x = solve_rank_one_update(b, kappa, A_solve=solve_diagonal, d=d, eta=eta)
+
+    np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)
+
+    # Verify H*x = b
+    np.testing.assert_allclose(H @ x, b, rtol=1e-8, atol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "seed,M,p",
+    [
+        (125, 100, 3),
+        (225, 200, 10),
+        (325, 50, 2),
+        (425, 500, 10),
+        (525, 13, 2),
+    ],
+)
+def test_solve_arrow_plus_rank_p_with_d(seed: int, M: int, p: int) -> None:
+    """Test solving H*x = b for H = arrow + kappa @ D @ kappa^T with diagonal D."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    zeta = np.random.randn(M)
+    theta = np.dot(zeta / eta, zeta) + 1.0
+
+    A = np.zeros((M + 1, M + 1))
+    A[0:M, 0:M] = np.diag(eta)
+    A[M, 0:M] = zeta
+    A[0:M, M] = zeta
+    A[M, M] = theta
+
+    kappa = np.random.randn(M + 1, p)
+    d = np.random.rand(p) + 0.5
+    H = A + kappa @ np.diag(d) @ kappa.T
+    b = np.random.randn(M + 1)
+
+    x_expected = np.linalg.solve(H, b)
+    x = solve_rank_p_update(
+        b, kappa, A_solve=solve_arrow_sparsity_pattern, d=d, eta=eta, zeta=zeta, theta=theta
+    )
+
+    np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)
+
+    # Verify H*x = b
+    np.testing.assert_allclose(H @ x, b, rtol=1e-8, atol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "seed,M,p,q",
+    [
+        (126, 100, 3, 20),
+        (226, 200, 10, 30),
+        (326, 50, 2, 5),
+        (426, 500, 10, 100),
+        (526, 13, 2, 3),
+    ],
+)
+def test_solve_arrow_plus_rank_p_with_d_multiple_rhs(
+    seed: int, M: int, p: int, q: int
+) -> None:
+    """Test solving H*x = b for H = arrow + kappa @ D @ kappa^T, multiple RHS."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    zeta = np.random.randn(M)
+    theta = np.dot(zeta / eta, zeta) + 1.0
+
+    A = np.zeros((M + 1, M + 1))
+    A[0:M, 0:M] = np.diag(eta)
+    A[M, 0:M] = zeta
+    A[0:M, M] = zeta
+    A[M, M] = theta
+
+    kappa = np.random.randn(M + 1, p)
+    d = np.random.rand(p) + 0.5
+    H = A + kappa @ np.diag(d) @ kappa.T
+    b = np.random.randn(M + 1, q)
+
+    x_expected = np.linalg.solve(H, b)
+    x = solve_rank_p_update(
+        b, kappa, A_solve=solve_arrow_sparsity_pattern, d=d, eta=eta, zeta=zeta, theta=theta
+    )
+
+    np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)
+
+    # Verify H*x = b
+    np.testing.assert_allclose(H @ x, b, rtol=1e-8, atol=1e-8)

--- a/test/test_numerical_helpers.py
+++ b/test/test_numerical_helpers.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 import pytest
 from scipy import linalg
 
+from cvxium.exceptions import NewtonStepError
 from cvxium.numerical_helpers import (
     multiply_arrow_sparsity_pattern,
     multiply_block_diagonal,
@@ -1197,4 +1198,207 @@ def test_solve_arrow_plus_rank_p_with_d_multiple_rhs(
     np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)
 
     # Verify H*x = b
+    np.testing.assert_allclose(H @ x, b, rtol=1e-8, atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Downdate solve tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "seed,M",
+    [
+        (127, 100),
+        (227, 200),
+        (327, 50),
+        (427, 500),
+        (527, 13),
+    ],
+)
+def test_solve_rank_one_downdate_pd(seed: int, M: int) -> None:
+    """Solve H*x = b for H = diag(eta) + d*kappa*kappa^T, d < 0, H still PD."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    kappa = np.random.randn(M)
+    # Choose |d| < 1 / (kappa^T A^{-1} kappa) so the downdate keeps H PD.
+    max_d = 1.0 / np.dot(kappa, kappa / eta)
+    d = -float(np.random.rand() * 0.5 * max_d)
+    H = np.diag(eta) + d * np.outer(kappa, kappa)
+    b = np.random.randn(M)
+
+    x_expected = np.linalg.solve(H, b)
+    x = solve_rank_one_update(b, kappa, A_solve=solve_diagonal, d=d, eta=eta)
+
+    np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)
+    np.testing.assert_allclose(H @ x, b, rtol=1e-8, atol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "seed,M",
+    [
+        (128, 100),
+        (228, 200),
+        (328, 50),
+        (428, 500),
+        (528, 13),
+    ],
+)
+def test_solve_rank_one_downdate_indefinite_raises(seed: int, M: int) -> None:
+    """NewtonStepError raised when rank-one downdate makes H indefinite."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    kappa = np.random.randn(M)
+    # Choose |d| > 1 / (kappa^T A^{-1} kappa) so the downdate makes H indefinite.
+    max_d = 1.0 / np.dot(kappa, kappa / eta)
+    d = -float((1.0 + np.random.rand()) * max_d)
+    b = np.random.randn(M)
+
+    with pytest.raises(NewtonStepError):
+        solve_rank_one_update(b, kappa, A_solve=solve_diagonal, d=d, eta=eta)
+
+
+@pytest.mark.parametrize(
+    "seed,M,p",
+    [
+        (129, 100, 3),
+        (229, 200, 10),
+        (329, 50, 2),
+        (429, 500, 10),
+        (529, 13, 2),
+    ],
+)
+def test_solve_rank_p_downdate_pd(seed: int, M: int, p: int) -> None:
+    """Solve H*x = b for H = arrow + kappa @ D @ kappa^T, all d < 0, H still PD."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    zeta = np.random.randn(M)
+    theta = np.dot(zeta / eta, zeta) + 1.0
+
+    A = np.zeros((M + 1, M + 1))
+    A[0:M, 0:M] = np.diag(eta)
+    A[M, 0:M] = zeta
+    A[0:M, M] = zeta
+    A[M, M] = theta
+
+    kappa = np.random.randn(M + 1, p)
+    # Scale kappa down so the downdate is small enough to keep H PD.
+    kappa = kappa / (np.linalg.norm(kappa) * 4)
+    d = -(np.random.rand(p) + 0.5)
+    H = A + kappa @ np.diag(d) @ kappa.T
+
+    # Verify H is actually PD before testing.
+    assert np.all(np.linalg.eigvalsh(H) > 0), "Test setup error: H is not PD"
+
+    b = np.random.randn(M + 1)
+
+    x_expected = np.linalg.solve(H, b)
+    x = solve_rank_p_update(
+        b,
+        kappa,
+        A_solve=solve_arrow_sparsity_pattern,
+        d=d,
+        eta=eta,
+        zeta=zeta,
+        theta=theta,
+    )
+
+    np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)
+    np.testing.assert_allclose(H @ x, b, rtol=1e-8, atol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "seed,M,p",
+    [
+        (130, 100, 3),
+        (230, 200, 10),
+        (330, 50, 2),
+        (430, 500, 10),
+        (530, 13, 2),
+    ],
+)
+def test_solve_rank_p_downdate_indefinite_raises(seed: int, M: int, p: int) -> None:
+    """NewtonStepError raised when rank-p downdate makes H indefinite."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    zeta = np.random.randn(M)
+    theta = np.dot(zeta / eta, zeta) + 1.0
+
+    A = np.zeros((M + 1, M + 1))
+    A[0:M, 0:M] = np.diag(eta)
+    A[M, 0:M] = zeta
+    A[0:M, M] = zeta
+    A[M, M] = theta
+
+    # Large kappa so the downdate dominates and H becomes indefinite.
+    kappa = np.random.randn(M + 1, p) * 5.0
+    d = -(np.random.rand(p) + 1.0)
+    H = A + kappa @ np.diag(d) @ kappa.T
+
+    # Verify H is actually indefinite before testing.
+    assert np.any(np.linalg.eigvalsh(H) < 0), "Test setup error: H is not indefinite"
+
+    b = np.random.randn(M + 1)
+
+    with pytest.raises(NewtonStepError):
+        solve_rank_p_update(
+            b,
+            kappa,
+            A_solve=solve_arrow_sparsity_pattern,
+            d=d,
+            eta=eta,
+            zeta=zeta,
+            theta=theta,
+        )
+
+
+@pytest.mark.parametrize(
+    "seed,M,p",
+    [
+        (131, 100, 4),
+        (231, 200, 6),
+        (331, 50, 3),
+        (431, 500, 8),
+        (531, 13, 3),
+    ],
+)
+def test_solve_rank_p_mixed_d(seed: int, M: int, p: int) -> None:
+    """Solve H*x = b for H = arrow + kappa @ D @ kappa^T with mixed-sign d, H PD."""
+    np.random.seed(seed)
+    eta = np.random.rand(M) + 1.0
+    zeta = np.random.randn(M)
+    theta = np.dot(zeta / eta, zeta) + 1.0
+
+    A = np.zeros((M + 1, M + 1))
+    A[0:M, 0:M] = np.diag(eta)
+    A[M, 0:M] = zeta
+    A[0:M, M] = zeta
+    A[M, M] = theta
+
+    # Scale kappa down so mixed d still leaves H PD.
+    kappa = np.random.randn(M + 1, p) / (np.linalg.norm(np.random.randn(M + 1, p)) * 4)
+    d = np.where(
+        np.arange(p) % 2 == 0,
+        np.random.rand(p) + 0.5,
+        -(np.random.rand(p) * 0.1),
+    )
+    H = A + kappa @ np.diag(d) @ kappa.T
+
+    # Verify H is actually PD before testing.
+    assert np.all(np.linalg.eigvalsh(H) > 0), "Test setup error: H is not PD"
+
+    b = np.random.randn(M + 1)
+
+    x_expected = np.linalg.solve(H, b)
+    x = solve_rank_p_update(
+        b,
+        kappa,
+        A_solve=solve_arrow_sparsity_pattern,
+        d=d,
+        eta=eta,
+        zeta=zeta,
+        theta=theta,
+    )
+
+    np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)
     np.testing.assert_allclose(H @ x, b, rtol=1e-8, atol=1e-8)

--- a/test/test_numerical_helpers.py
+++ b/test/test_numerical_helpers.py
@@ -1138,7 +1138,13 @@ def test_solve_arrow_plus_rank_p_with_d(seed: int, M: int, p: int) -> None:
 
     x_expected = np.linalg.solve(H, b)
     x = solve_rank_p_update(
-        b, kappa, A_solve=solve_arrow_sparsity_pattern, d=d, eta=eta, zeta=zeta, theta=theta
+        b,
+        kappa,
+        A_solve=solve_arrow_sparsity_pattern,
+        d=d,
+        eta=eta,
+        zeta=zeta,
+        theta=theta,
     )
 
     np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)
@@ -1179,7 +1185,13 @@ def test_solve_arrow_plus_rank_p_with_d_multiple_rhs(
 
     x_expected = np.linalg.solve(H, b)
     x = solve_rank_p_update(
-        b, kappa, A_solve=solve_arrow_sparsity_pattern, d=d, eta=eta, zeta=zeta, theta=theta
+        b,
+        kappa,
+        A_solve=solve_arrow_sparsity_pattern,
+        d=d,
+        eta=eta,
+        zeta=zeta,
+        theta=theta,
     )
 
     np.testing.assert_allclose(x, x_expected, rtol=1e-8, atol=1e-8)


### PR DESCRIPTION
Introduces cvxium/multi_objective.py with three public classes:

- FrontierPoint: dataclass holding objectives, solution, bounds, and the
  raw IPM result at one point on the frontier.
- FrontierResults: collection of frontier points and corner points, with
  a knee() method that finds the point maximally distant from the
  hyperplane through the N corner points (generalizes the 2-D max-chord-
  distance to arbitrary N via SVD of the translated corner matrix).
- MultiObjectiveOptimizer: abstract base class. Subclasses implement
  solve_with_bounds(), minimize_objective(), and evaluate_objectives();
  the concrete trace() method sweeps a uniform grid over auxiliary-
  objective bounds, auto-detects the sweep range from the corner solves,
  and silently skips infeasible grid points.

Exports the three classes from the top-level cvxium package.
Adds 21 passing tests covering 2- and 3-objective problems, monotonicity,
analytical frontier accuracy, and knee geometry.

https://claude.ai/code/session_01PabCXrsUGN9kextx5tz1VZ