### PR TITLE
Refactor hessian_multiply to use numerical helper multiply_* functions

### DIFF
--- a/cvxium/linear_programs.py
+++ b/cvxium/linear_programs.py
@@ -11,6 +11,10 @@ from scipy import linalg
 
 from .exceptions import NewtonStepError, ProblemInfeasibleError
 from .numerical_helpers import (
+    multiply_arrow_sparsity_pattern,
+    multiply_block_plus_one,
+    multiply_diagonal,
+    multiply_rank_p_update,
     solve_block_plus_one,
     solve_diagonal_eta_inverse,
     solve_kkt_system,
@@ -578,14 +582,10 @@ class EqualityWithBoundsSolver(FeasibilityInteriorPointSolver):
 
 
         """
-        M = self.dimension
         eta = self._hessian_ft_diagonal(x, t)
         zeta = self._hessian_ft_edge(x)
         theta = self._hessian_ft_corner(x)
-        Hy = np.zeros_like(y)
-        Hy[0:M] = eta * y[0:M] + y[M] * zeta
-        Hy[M] = np.dot(zeta, y[0:M]) + theta * y[M]
-        return Hy
+        return multiply_arrow_sparsity_pattern(y, eta, zeta, theta)
 
     def _hessian_ft_diagonal(
         self, x: npt.NDArray[np.float64], t: float
@@ -1096,37 +1096,22 @@ class EqualityWithBoundsAndImbalanceConstraintSolver(
 
         """
         M = self.dimension
-        y_x = y[:M]  # shape (M,)
-        y_s = y[M]  # scalar
-
         Bx_minus_c = self.B @ x[:M] - self.c  # shape (q,)
 
-        # Diagonal component
         eta = self._hessian_ft_diagonal(x)  # shape (M,)
-
-        # Rank-q factors
         kappa_pos = self._hessian_ft_kappa_pos(x, Bx_minus_c)  # shape (M, q)
         kappa_neg = self._hessian_ft_kappa_neg(x, Bx_minus_c)  # shape (M, q)
-
-        # Mixed derivatives
         hxs = self._hessian_ft_edge(x, Bx_minus_c)  # shape (M,)
         hss = self._hessian_ft_corner(x, Bx_minus_c)  # scalar
 
-        # Compute Hxx * y_x
-        Hxx_yx = (  # shape (M,)
-            eta * y_x
-            + kappa_pos @ (kappa_pos.T @ y_x)
-            + kappa_neg @ (kappa_neg.T @ y_x)
-        )
+        # Hxx = diag(eta) + kappa_pos @ kappa_pos^T + kappa_neg @ kappa_neg^T
+        def diag_plus_neg(z: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return multiply_rank_p_update(z, kappa_neg, multiply_diagonal, eta=eta)
 
-        # Add mixed derivative term
-        Hy_x = Hxx_yx + hxs * y_s  # shape (M,)
+        def hxx_multiply(z: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return multiply_rank_p_update(z, kappa_pos, diag_plus_neg)
 
-        # Compute lower block: Hxs^T y_x + Hss * y_s
-        Hy_s = np.dot(hxs, y_x) + hss * y_s  # scalar
-
-        # Concatenate result
-        return np.append(Hy_x, Hy_s)
+        return multiply_block_plus_one(y, hxs, hss, hxx_multiply)
 
     def _hessian_ft_diagonal(
         self, x: npt.NDArray[np.float64]

--- a/cvxium/quadratic_programs.py
+++ b/cvxium/quadratic_programs.py
@@ -10,6 +10,8 @@ from scipy import linalg
 
 from .linear_programs import EqualityWithBoundsSolver
 from .numerical_helpers import (
+    multiply_diagonal,
+    multiply_rank_p_update,
     solve_diagonal_eta_inverse,
     solve_kkt_system,
     solve_rank_p_update,
@@ -440,10 +442,11 @@ class QuadraticProgramEqualityBoundsSolver(
                 # Q_vector_multiply handles (scale * Q + diag(diag_add)) directly.
                 # scale=2t > 0 and diag_add=d >= 0 are guaranteed by the barrier.
                 return self._Q_vector_multiply(y, scale=2.0 * t, diag_add=d)  # type: ignore[call-arg]
-            return 2.0 * t * self._Q_vector_multiply(y) + d * y
+            return 2.0 * t * self._Q_vector_multiply(y) + multiply_diagonal(y, d)
         if self._kappa_cache is not None:
-            return 2.0 * t * (self._kappa_cache @ (self._kappa_cache.T @ y)) + d * y
-        return 2.0 * t * (self.Q @ y) + d * y
+            kappa = np.sqrt(2.0 * t) * self._kappa_cache
+            return multiply_rank_p_update(y, kappa, multiply_diagonal, eta=d)
+        return multiply_diagonal(y, d) + 2.0 * t * (self.Q @ y)
 
     # ------------------------------------------------------------------
     # Newton step


### PR DESCRIPTION
- EqualityWithBoundsSolver: replace manual arrow-pattern multiply with
  multiply_arrow_sparsity_pattern
- EqualityWithBoundsAndImbalanceConstraintSolver: replace manual block
  multiply with multiply_block_plus_one, and the rank-q updates with
  multiply_rank_p_update composed via closures
- QuadraticProgramEqualityBoundsSolver: replace kappa_cache path with
  multiply_rank_p_update(y, sqrt(2t)*kappa, multiply_diagonal, eta=d),
  and use multiply_diagonal for the d*y term throughout

https://claude.ai/code/session_01LuSjHL3xPtaoa3VzsdzjJp